### PR TITLE
Added setup.py for pip install which also installs a 'hsp2' command

### DIFF
--- a/HSP2notebooks/Data/test10.uci
+++ b/HSP2notebooks/Data/test10.uci
@@ -11,7 +11,7 @@ END GLOBAL
 
 FILES      
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
-WDM        21   test.wdm
+WDM        21   test10.wdm
 MESSU      22   test10.ech
            01   test10.out
            66   test10.d66

--- a/HSP2tools/HSP2_CLI.py
+++ b/HSP2tools/HSP2_CLI.py
@@ -1,0 +1,60 @@
+import mando
+
+from HSP2.main import main as hsp2main
+from HSP2tools.readUCI import readUCI
+from HSP2tools.readWDM import readWDM
+
+
+@mando.command(doctype="numpy")
+def run(hdfname, saveall=False, jupyterlab=False):
+    """Run a HSPsquared model.
+
+    Parameters
+    ----------
+    hdfname: str
+        HDF5 (path) filename used for both input and output.
+    saveall: bool
+        [optional] Default is False.
+        Saves all calculated data ignoring SAVE tables.
+    jupyterlab: bool
+        Jupyterlab
+    """
+    hsp2main(hdfname, saveall=saveall, jupyterlab=jupyterlab)
+
+
+@mando.command(doctype="numpy")
+def import_uci(ucifile, h5file):
+    """Import UCI and WDM files into HDF5 file.
+
+    Parameters
+    ----------
+    ucifile: str
+        The UCI file to import into HDF file.
+    h5file: str
+        The destination HDF5 file.
+    """
+    readUCI(ucifile, h5file)
+
+    with open(ucifile, "r") as fp:
+        uci = []
+        for line in fp.readlines():
+            if '***' in line[:81]:
+                continue
+            if not line[:81].strip():
+                continue
+            uci.append(line[:81].rstrip())
+
+    files_start = uci.index("FILES")
+    files_end = uci.index("END FILES")
+
+    for nline in uci[files_start: files_end+1]:
+        if nline[:10].strip() == "WDM":
+            readWDM(nline[16:].strip(), h5file)
+
+
+def main():
+    mando.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/environment.yml
+++ b/environment.yml
@@ -43,3 +43,4 @@ dependencies:
       # See https://github.com/jupyterlab/jupyterlab-hdf5/issues/42#issuecomment-801786628
     # - jupyterlab_hdf  # https://github.com/jupyterlab/jupyterlab-hdf5
     # - hdf5plugin  # https://github.com/jupyterlab/jupyterlab-hdf5#compression-filters
+    - mando

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -47,3 +47,4 @@ dependencies:
       # See https://github.com/jupyterlab/jupyterlab-hdf5/issues/42#issuecomment-801786628
     # - jupyterlab_hdf  # https://github.com/jupyterlab/jupyterlab-hdf5
     # - hdf5plugin  # https://github.com/jupyterlab/jupyterlab-hdf5#compression-filters
+    - mando

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
     url="http://www.respec.com/product/hydrologic-simulation-program-python-hsp%C2%B2/",
     packages=["HSP2", "HSP2tools"],
     include_package_data=True,
+    package_data={"HSP2tools": ["data/*"]},
     zip_safe=False,
     install_requires=install_requires,
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,109 @@
+import os
+import re
+import shlex
+import sys
+
+from HSP2 import __version__
+
+from setuptools import setup
+
+if sys.argv[-1] == "publish":
+    os.system(shlex.quote("cleanpy ."))
+    os.system(shlex.quote("python setup.py sdist"))
+    os.system(shlex.quote(f"twine upload dist/HSPsquared-{__version__}.tar.gz"))
+    sys.exit()
+
+README = open("./README.md").read()
+
+pypi_map = {"jupyter-lsp-python": "python-lsp-server[all]"}
+
+
+def process_env_yaml(fname, dev=False):
+    yaml_lines = []
+    with open("environment.yml") as fp:
+        collect = False
+        for line in fp.readlines():
+            # Handle comments
+            line = line.split("#")[0].rstrip()
+
+            # Handle blank lines
+            if not line.strip():
+                continue
+
+            line = line.strip(" -").replace(" ", "")
+
+            if collect is True:
+                words = re.split("=|<|>", line)
+                # Shouldn't have interactivity, development tools, conda, pip,
+                # or python as a dependency.
+                if dev is True:
+                    if words[0] in ["conda", "conda-build", "pip", "python", "pip:"]:
+                        continue
+                else:
+                    if words[0] in [
+                        "jupyterlab",
+                        "ipywidgets",
+                        "matplotlib",
+                        "conda",
+                        "conda-build",
+                        "pip",
+                        "python",
+                        "lckr-jupyterlab-variableinspector",
+                        "jupyter-lsp-python",
+                        "jupyterlab-lsp",
+                        "pip:",
+                    ]:
+                        continue
+
+                # On PyPI pytables is tables.
+                if words[0] == "pytables":
+                    line = line.replace("pytables", "tables")
+
+                yaml_lines.append(line)
+
+            if line.rstrip() == "dependencies:":
+                collect = True
+    yaml_lines = [pypi_map.get(i, i) for i in yaml_lines]
+    return yaml_lines
+
+
+install_requires = process_env_yaml("environment.yml")
+extras_require = {
+    "dev": process_env_yaml("environment_dev.yml", dev=True) + ["cleanpy", "twine"]
+}
+
+setup(
+    name="HSPsquared",
+    version=__version__,
+    description="Hydrological Simulation Program - Python",
+    long_description=README,
+    classifiers=[
+        # Get strings from
+        # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Developers",
+        "Environment :: Console",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    keywords="hydrology hydrological hydraulic hspf",
+    author="RESPEC, Inc",
+    author_email="",
+    url="http://www.respec.com/product/hydrologic-simulation-program-python-hsp%C2%B2/",
+    packages=["HSP2", "HSP2tools"],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=install_requires,
+    extras_require=extras_require,
+    entry_points={"console_scripts": ["hsp2=HSP2tools.HSP2_CLI:main"]},
+    test_suite="tests",
+    python_requires=">3.6",
+)

--- a/tests/ZRW_WestIndian/HSPF.uci
+++ b/tests/ZRW_WestIndian/HSPF.uci
@@ -16,7 +16,7 @@ FILES
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
 MESSU      24   HSPF.ECH
            25   HSPF.OUT
-WDM1       26   MET4.WDM
+WDM1       26   Met4.WDM
 WDM2       27   HSPF.WDM
 WDM3       28   ZUMBROSCEN.WDM
 BINO       92   HSPF.HBN

--- a/tests/test09/HSP2compare/TEST09.UCI
+++ b/tests/test09/HSP2compare/TEST09.UCI
@@ -9,7 +9,7 @@ END GLOBAL
 
 FILES      
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
-WDM        21   test.wdm
+WDM        21   TEST.WDM
 MESSU      22   test09.ech
            01   test09.out
            65   test09.d65

--- a/tests/test09/HSP2compare/TEST09bin.UCI
+++ b/tests/test09/HSP2compare/TEST09bin.UCI
@@ -9,7 +9,7 @@ END GLOBAL
 
 FILES      
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
-WDM        21   test.wdm
+WDM        21   TEST.WDM
 MESSU      22   test09.ech
            01   test09.out
            65   test09.d65

--- a/tests/test10/HSP2results/test10.uci
+++ b/tests/test10/HSP2results/test10.uci
@@ -11,7 +11,7 @@ END GLOBAL
 
 FILES      
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
-WDM        21   test.wdm
+WDM        21   test10.wdm
 MESSU      22   test10.ech
            01   test10.out
            66   test10.d66

--- a/tests/test10/HSPFresults/test10.uci
+++ b/tests/test10/HSPFresults/test10.uci
@@ -11,7 +11,7 @@ END GLOBAL
 
 FILES      
 <FILE>  <UN#>***<----FILE NAME------------------------------------------------->
-WDM        21   test.wdm
+WDM        21   test10.wdm
 MESSU      22   test10.ech
            01   test10.out
            66   test10.d66


### PR DESCRIPTION
Added a setup.py command which:

- processes the conda "environment.yml" and "environment_dev.yml" files to update dependencies in one place
- installs a 'hsp2' command line interface
- has a "python setup.py publish" command which will package and upload the package to pypi.org
- pull version number from "`__version__`" variable in "`HSP2/__init__.py`" so version number is kept in one place

The only change made to any conda settings was to add the "mando" library to the "environment*.yml" files.  "mando" is used to support the command line environment.

To install from the current local directory using pip:
`pip install .
`

To install from the current local directory including the "dev" dependencies:
`pip install .[dev]
`

To install an editable version from the current local directory using pip:
`pip install -e .
`

And of course if RESPEC published the package to pypi.org (setting up an account and running "python setup.py publish") then to install HSPsquared and all dependencies from any python environment anywhere in the world:
`pip install HSPsquared
`

## hsp2 Command

The pip installed 'hsp2' command has help created from the function docstrings in HSP2tools/HSP2_CLI.py.

### hsp2 --help
```
usage: hsp2 [-h] {run,import_uci} ...

positional arguments:
  {run,import_uci}
    run             Run a HSPsquared model.
    import_uci      Import UCI and WDM files into HDF5 file.

optional arguments:
  -h, --help        show this help message and exit
```
And there is a help for each sub-command:

### hsp2 import_uci --help
```
usage: hsp2 import_uci [-h] ucifile h5file

Import UCI and WDM files into HDF5 file.

positional arguments:
  ucifile     The UCI file to import into HDF file.
  h5file      The destination HDF5 file.

optional arguments:
  -h, --help  show this help message and exit
```
### hsp2 run --help
```
usage: hsp2 run [-h] [--saveall] [--jupyterlab] hdfname

Run a HSPsquared model.

positional arguments:
  hdfname       HDF5 (path) filename used for both input and output.

optional arguments:
  -h, --help    show this help message and exit
  --saveall     [optional] Default is False. Saves all calculated data ignoring SAVE tables.
  --jupyterlab  Jupyterlab
```

Intended workflow from the command line would be something like:

```
hsp2 import_uci import_test.uci new_model.h5
# The previous command will import all WDM files listed in the "FILES" block along with the tables in the UCI file.
hsp2 run new_model.h5

```