### PR TITLE
Fix Issue#77 (saveall=false) bug

### DIFF
--- a/HSP2/utilities.py
+++ b/HSP2/utilities.py
@@ -286,11 +286,9 @@ def get_timeseries(timeseries_inputs:SupportsReadTS, ext_sourcesdd, siminfo):
     return ts
 
 def save_timeseries(timeseries:SupportsWriteTS, ts, savedict, siminfo, saveall, operation, segment, activity, compress=True):
-    # save computed timeseries (at computation DELT)
-    save = {k for k,v in savedict.items() if v or saveall}
     df = pd.DataFrame(index=siminfo['tindex'])
     if (operation == 'IMPLND' and activity == 'IQUAL') or (operation == 'PERLND' and activity == 'PQUAL'):
-        for y in save:
+        for y in savedict.keys():
             for z in set(ts.keys()):
                 if '/' + y in z:
                     zrep = z.replace('/','_')
@@ -298,23 +296,24 @@ def save_timeseries(timeseries:SupportsWriteTS, ts, savedict, siminfo, saveall, 
                     df[zrep2] = ts[z]
                 if '_' + y in z:
                     df[z] = ts[z]
-        df = df.astype(np.float32).sort_index(axis='columns')
     elif (operation == 'RCHRES' and (activity == 'CONS' or activity == 'GQUAL')):
-        for y in save:
+        for y in savedict.keys():
             for z in set(ts.keys()):
                 if '_' + y in z:
                     df[z] = ts[z]
-        for y in (save & set(ts.keys())):
+        for y in (savedict.keys() & set(ts.keys())):
             df[y] = ts[y]
-        df = df.astype(np.float32).sort_index(axis='columns')
     else:
-        for y in (save & set(ts.keys())):
+        for y in (savedict.keys() & set(ts.keys())):
             df[y] = ts[y]
-        df = df.astype(np.float32).sort_index(axis='columns')
-    path = f'RESULTS/{operation}_{segment}/{activity}'
+    df = df.astype(np.float32).sort_index(axis='columns')
+    
+    save_columns = [key for key,value in savedict.items() if value or saveall]
+
     if not df.empty:
         timeseries.write_ts(
             data_frame=df,
+            save_columns=save_columns,
             category = Category.RESULTS,
             operation=operation,
             segment=segment,
@@ -322,7 +321,7 @@ def save_timeseries(timeseries:SupportsWriteTS, ts, savedict, siminfo, saveall, 
             compress=compress
         )
     else:
-        print('Save DataFrame Empty for', path)
+        print(f'DataFrame Empty for {operation}|{activity}|{segment}')
     return
 
 def expand_timeseries_names(sgrp, smemn, smemsb1, smemsb2, tmemn, tmemsb1, tmemsb2):

--- a/HSP2IO/io.py
+++ b/HSP2IO/io.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from pandas.core.frame import DataFrame
 from HSP2IO.protocols import Category, SupportsReadUCI, SupportsReadTS, SupportsWriteTS, SupportsWriteLogging
-from typing import Union
+from typing import Union, List
 
 from HSP2.uci import UCI
 
@@ -56,15 +56,21 @@ class IOManager:
 		return self._uci.read_uci()
 
 	def write_ts(self,
-			data_frame:pd.DataFrame, 
+			data_frame:pd.DataFrame,
+			save_columns: List[str], 
 			category:Category,
 			operation:Union[str,None]=None, 
 			segment:Union[str,None]=None, 
 			activity:Union[str,None]=None,
 			*args, **kwargs) -> None:
 		key = (category, operation, segment, activity)
-		self._output.write_ts(data_frame, category, operation, segment, activity)
 		self._in_memory[key] = data_frame.copy(deep=True)
+		
+		drop_columns = [c for c in data_frame.columns if c not in save_columns ] 
+		if drop_columns:
+			data_frame = data_frame.drop(columns=drop_columns)
+
+		self._output.write_ts(data_frame, category, operation, segment, activity)
 
 	def read_ts(self,
 			category:Category,


### PR DESCRIPTION
Reference #77. This commit modifies the save_timeseries function to generate a list of the columns in the dataframe that should be saved and now passes the dataframe to the IOManager. The logic for selectively removing columns prior to export is now handled by the IOManager. However, the IOManager first caches the dataframe will all columns in memory prior to selectively dropping columns. This allows subsequent modules to access those timeseries without saving them to the output file.