### PR TITLE
incorrect timeseries key assignment for inorganic nutrient species

### DIFF
--- a/HSP2/utilities.py
+++ b/HSP2/utilities.py
@@ -270,6 +270,8 @@ def get_timeseries(timeseries_inputs:SupportsReadTS, ext_sourcesdd, siminfo):
                 tname = 'ISED1'
             else:
                 tname = 'ISED' + row.TMEMSB[0]
+        elif row.TMEMN == 'NUIF1':
+            tname = row.TMEMN + '_' + row.TMEMSB[0]
         elif row.TMEMN in {'ICON', 'IDQAL', 'ISQAL'}:
             tmemsb1 = '1'
             tmemsb2 = '1'


### PR DESCRIPTION
@PaulDudaRESPEC @aufdenkampe @bcous 

This is fix for a bug that @bcous discovered when trying to run HSP2 for some project work. He noticed that the timeseries he specified for inorganic nutrient species were not being correctly input into RQUAL and NUTRX modules.

We determined the timeseries for inorganic species of nutrients were being assigned an incorrect key in the timeseries dictionary returned by the utlities.get_stimeseries function. The timeseries were not coded with an underscore between the TMEMN and TMEMSB definitions (i.e. NUIF11 instead of NUIF1_1)  as expected by the this section of RQUAL module https://github.com/respec/HSPsquared/blob/f9555f2e48cc3409f33c29d3c6504d9bdc0f91fb/HSP2/RQUAL_Class.py#L439-L449.