### PR TITLE
make state float64 instead of float32

### DIFF
--- a/HSP2/om.py
+++ b/HSP2/om.py
@@ -165,7 +165,7 @@ def state_om_model_run_prep(state, io_manager, siminfo):
     state['model_object_cache'] = model_object_cache
     state['model_exec_list'] = np.asarray(model_exec_list, dtype="i8") 
     if ModelObject.ops_data_type == 'ndarray':
-        state['state_ix'] = np.asarray(list(state['state_ix'].values()), dtype="float32")
+        state['state_ix'] = np.asarray(list(state['state_ix'].values()), dtype="float64")
     state['op_tokens'] = op_tokens 
     if len(op_tokens) > 0:
         state['state_step_om'] = 'enabled' 


### PR DESCRIPTION
Runtime difference of ~ +1%

Benchmark.py with `state_ix` as float32:
```
cd tests/testcbp/HSP2results/                                                                  
PS C:\usr\local\home\git\HSPsquared\tests\testcbp\HSP2results> py .\benchmark.py
Init HYDR state context for domain /STATE/RCHRES_R001
Tokenizing models
1001 components iterated over state_ix 324336 time steps took 51.58777570724487 seconds
1001 components iterated over np_state_ix 324336 time steps took 19.793294191360474 seconds
PS C:\usr\local\home\git\HSPsquared\tests\testcbp\HSP2results> 
```
With `state_ix` as float64
```
py benchmark.py 
Init HYDR state context for domain /STATE/RCHRES_R001
Tokenizing models
1001 components iterated over state_ix 324336 time steps took 51.935609102249146 seconds
1001 components iterated over np_state_ix 324336 time steps took 20.172362565994263 seconds
```