### PR TITLE
Run tests on 3 branches

### DIFF
--- a/.github/workflows/hsp2-conda-install-test-dev.yml
+++ b/.github/workflows/hsp2-conda-install-test-dev.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master", "develop-tests", "develop-specact-speed-eq" ]
+    branches: [ "master", "develop", "develop-specact" ]
 
 permissions:
   contents: read

--- a/.github/workflows/hsp2-pip-install-test-dev.yml
+++ b/.github/workflows/hsp2-pip-install-test-dev.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master", "develop-tests", "develop-specact-speed-eq" ]
+    branches: [ "master", "develop", "develop-specact" ]
 
 permissions:
   contents: read

--- a/.github/workflows/hsp2-pip-install-test.yml
+++ b/.github/workflows/hsp2-pip-install-test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master", "develop-tests", "develop-specact-speed-eq" ]
+    branches: [ "master", "develop", "develop-specact" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
> if I were to accept this PR as is, what would be the effect of these failed tests? Maybe they should be left out of the PR until we get those details resolved?

- The failed tests don't do anything, unless we require all tests to pass in order to do a merge (but I am pretty sure the system doesn't prevent it).
- My thinking (maybe flawed) is that the only way to test **if the dev install test is correct** is to have a runnable test, and to try, hence why I included them.
- We **can, however** disable these tests once they are merged into the `develop` branch, and thus are in the system.  To disable, go to "Actions" -> "Pyton conda dev application" and click on "Disable workflow" (see image below)
   - BUT, since now we already know the current test doesn't function, we can omit it, however, I was struggling to figure out a way to insure that the code was there in case someone else wanted to give it a whirl and didn't want to start from scratch, or at least wanted my example of what *not* to do.

![image](https://github.com/respec/HSPsquared/assets/4571170/a756eba3-8ab8-46c6-8869-1a8eb1c9a85a)

