### PR TITLE
Develop specact depend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,16 +56,19 @@ tests/_LargeFileStash
 # Temporary files
 _TutorialData/
 
+
 # Specific files
 run.py
 tests/GLWACSO/HSP2results/hspp007.hdf
 tests/GLWACSO/HSPFresults/hspf006.HBN
 tests/GLWACSO/HSP2results/hspp007.uci
 tests/test_report_conversion.html
+
+# Omit big files
 tests/land_spec/hwmA51800.h5
 tests/testcbp/HSP2results/PL3_5250_0001.h5
-tests/testcbp/HSP2results/PL3_5250_specl.h5
 tests/testcbp/HSP2results/*.csv
+tests/test10/HSP2results/test10.h5
 
 # R files
 .Rdata

--- a/HSP2/HYDR.py
+++ b/HSP2/HYDR.py
@@ -148,14 +148,13 @@ def hydr(io_manager, siminfo, uci, ts, ftables, state):
         from hsp2_local_py import state_step_hydr
     else:
         from HSP2.state_fn_defaults import state_step_hydr
+    # initialize the hydr paths in case they don't already reside here
+    hydr_init_ix(state, state['domain'])
     # must split dicts out of state Dict since numba cannot handle mixed-type nested Dicts
     state_ix, dict_ix, ts_ix = state['state_ix'], state['dict_ix'], state['ts_ix']
     state_paths = state['state_paths']
     model_exec_list = state['model_exec_list'] # order of special actions and other dynamic ops
-    # initialize the hydr paths in case they don't already reside here
-    hydr_init_ix(state_ix, state_paths, state['domain'])
     op_tokens = state['op_tokens']
-    print("state_ix is type", type(state_ix))
     #######################################################################################
 
     # Do the simulation with _hydr_   (ie run reaches simulation code)
@@ -173,7 +172,7 @@ def hydr(io_manager, siminfo, uci, ts, ftables, state):
     return errors, ERRMSGS
 
 
-@njit(cache=True)
+@njit
 def _hydr_(ui, ts, COLIND, OUTDGT, rowsFT, funct, Olabels, OVOLlabels, state_info, state_paths, state_ix, dict_ix, ts_ix, state_step_hydr, op_tokens, model_exec_list):
     errors = zeros(int(ui['errlen'])).astype(int64)
 

--- a/HSP2/SPECL.py
+++ b/HSP2/SPECL.py
@@ -13,13 +13,6 @@ import h5py
 def specl_load_actions(state, io_manager, siminfo):
     if 'ACTIONS' in state['specactions']:
         dc = state['specactions']['ACTIONS']
-        #print(dc.index)
-        #print("speca entry 0:0", dc[0:0])
-        #print("speca entry 0:1", dc[0:1])
-        #print("speca entry 1:2", dc[1:2])
-        #print("speca entry 0:", dc[0:])
-        #print("speca entry 1:", dc[1:])
-        #print("speca entry 1:1", dc[1:1])
         for ix in dc.index:
             # add the items to the state['model_data'] dict
             speca = dc[ix:(ix+1)]

--- a/HSP2/main.py
+++ b/HSP2/main.py
@@ -69,18 +69,10 @@ def main(io_manager:IOManager, saveall:bool=False, jupyterlab:bool=True) -> None
     state_load_dynamics_hsp2(state, io_manager, siminfo)
     # Iterate through all segments and add crucial paths to state 
     # before loading dynamic components that may reference them
-    for _, operation, segment, delt in opseq.itertuples():
-        if operation != 'GENER' and operation != 'COPY':
-            for activity, function in activities[operation].items():
-                if activity == 'HYDR':
-                    state_context_hsp2(state, operation, segment, activity)
-                    print("Init HYDR state context for domain", state['domain'])
-                    hydr_init_ix(state['state_ix'], state['state_paths'], state['domain'])
-                elif activity == 'SEDTRN':
-                    state_context_hsp2(state, operation, segment, activity)
-                    sedtrn_init_ix(state['state_ix'], state['state_paths'], state['domain'])
+    state_init_hsp2(state, opseq, activities)
     # - finally stash specactions in state, not domain (segment) dependent so do it once
     state['specactions'] = specactions # stash the specaction dict in state
+    state_initialize_om(state)
     state_load_dynamics_specl(state, io_manager, siminfo)   # traditional special actions
     state_load_dynamics_om(state, io_manager, siminfo)      # operational model for custom python
     # finalize all dynamically loaded components and prepare to run the model

--- a/HSP2/om.py
+++ b/HSP2/om.py
@@ -55,11 +55,11 @@ def is_float_digit(n: str) -> bool:
 # Import Code Classes
 from HSP2.om_model_object import *
 from HSP2.om_sim_timer import *
-from HSP2.om_equation import *
+#from HSP2.om_equation import *
 from HSP2.om_model_linkage import *
 from HSP2.om_special_action import *
-from HSP2.om_data_matrix import *
-from HSP2.om_model_broadcast import *
+#from HSP2.om_data_matrix import *
+#from HSP2.om_model_broadcast import *
 #from HSP2.om_simple_channel import *
 #from HSP2.om_impoundment import *
 from HSP2.utilities import versions, get_timeseries, expand_timeseries_names, save_timeseries, get_gener_timeseries

--- a/HSP2/om_model_linkage.py
+++ b/HSP2/om_model_linkage.py
@@ -70,7 +70,7 @@ class ModelLinkage(ModelObject):
         # do we need to do this, or just trust it exists?
         #self.insure_path(self, self.right_path)
         # the left path, if this is type 4 or 5, is a push, so we must require it 
-        if ( (self.link_type == 4) or (self.link_type == 5) ):
+        if ( (self.link_type == 4) or (self.link_type == 5) or (self.link_type == 6) ):
             self.insure_path(self.left_path)
         self.paths_found = True
         return 
@@ -88,7 +88,7 @@ class ModelLinkage(ModelObject):
             else:
                 print("Error: link ", self.name, "does not have a valid source path")
             #print(self.name,"tokenize() result", self.ops)
-        if (self.link_type == 4) or (self.link_type == 5):
+        if (self.link_type == 4) or (self.link_type == 5) or (self.link_type == 6):
             # we push to the remote path in this one 
             left_ix = get_state_ix(self.state_ix, self.state_paths, self.left_path)
             right_ix = get_state_ix(self.state_ix, self.state_paths, self.right_path)
@@ -107,6 +107,7 @@ def step_model_link(op_token, state_ix, ts_ix, step):
         return True
     elif op_token[3] == 2:
         state_ix[op_token[1]] = state_ix[op_token[2]]
+        return True
     elif op_token[3] == 3:
         # read from ts variable TBD
         # state_ix[op_token[1]] = ts_ix[op_token[2]][step]
@@ -117,29 +118,9 @@ def step_model_link(op_token, state_ix, ts_ix, step):
         return True
     elif op_token[3] == 5:
         # overwrite remote variable state with value in another paths state
-        if step == 2:
-            print("Setting state_ix[", op_token[2], "] =", state_ix[op_token[4]])
         state_ix[op_token[2]] = state_ix[op_token[4]]
         return True
-
-
-def test_model_link(op_token, state_ix, ts_ix, step):
-    if op_token[3] == 1:
-        return True
-    elif op_token[3] == 2:
-        state_ix[op_token[1]] = state_ix[op_token[2]]
-    elif op_token[3] == 3:
-        # read from ts variable TBD
-        # state_ix[op_token[1]] = ts_ix[op_token[2]][step]
-        return True
-    elif op_token[3] == 4:
-        print("Remote Broadcast accumulator type link.")
-        print("Setting op ID", str(op_token[2]), "to value from ID", str(op_token[4]), "with value of ")
-        # add value in local state to the remote broadcast hub+register state 
-        state_ix[op_token[2]] = state_ix[op_token[2]] + state_ix[op_token[4]]
-        print(str(state_ix[op_token[2]]) + " = ", str(state_ix[op_token[2]]) + "+" + str(state_ix[op_token[4]]))
-        return True
-    elif op_token[3] == 5:
-        # push value in local state to the remote broadcast hub+register state 
-        state_ix[op_token[2]] = state_ix[op_token[4]]
+    elif op_token[3] == 6:
+        # set value in a timerseries
+        ts_ix[op_token[2]][step] = state_ix[op_token[4]] 
         return True

--- a/HSP2/om_special_action.py
+++ b/HSP2/om_special_action.py
@@ -36,7 +36,15 @@ class SpecialAction(ModelObject):
         self.timer_ix = self.handle_prop(model_props, 'when', False, 1) # when to begin the first attempt at action
         self.ctr_ix = self.constant_or_path('ctr', 0) # this initializes the counter for how many times an action has been performed
         # now add the state value that we are operating on (the target) as an input, so that this gets executed AFTER this is set initially
-        self.add_input('op1', ('/STATE/' + self.op_type + '_' + self.op_type[0] + str(self.range1).zfill(3) + "/" + self.vari ), 2, True )
+        #self.add_input('op1', ('/STATE/' + self.op_type + '_' + self.op_type[0] + str(self.range1).zfill(3) + "/" + self.vari ), 2, True )
+        # or, should we set up a register for the target 
+        domain = self.model_object_cache[('/STATE/' + self.op_type + '_' + self.op_type[0] + str(self.range1).zfill(3) )]
+        var_register = self.insure_register(self.vari, 0.0, domain, False)
+        #print("Created register", var_register.name, "with path", var_register.state_path)
+        # add already created objects as inputs
+        var_register.add_object_input(self.name, self, 1)
+        self.op1_ix = var_register.ix
+
         # @tbd: support time enable/disable
         #       - check if time ops have been set and add as inputs like "year", or "month", etc could give explicit path /STATE/year ...
         #       - add the time values to match as constants i.e. self.constant_or_path()
@@ -52,7 +60,7 @@ class SpecialAction(ModelObject):
         if (prop_name == 'when'):
            # when to perform this?  timestamp or time-step index
            prop_val = 0
-           si = ModelObject.model_object_cache['/STATE/timer']
+           si = self.model_object_cache[self.find_var_path('timer')]
            if len(model_props['YR']) > 0:
                # translate date to equivalent model step
                datestring = model_props['YR'] + '-' + model_props['MO'] + '-' + \
@@ -105,7 +113,7 @@ class SpecialAction(ModelObject):
     def tokenize(self):
         # call parent method to set basic ops common to all 
         super().tokenize() # sets self.ops = op_type, op_ix
-        self.ops = self.ops + [self.inputs_ix['op1'], self.opid, self.op2_ix, self.timer_ix, self.ctr_ix, self.num]
+        self.ops = self.ops + [self.op1_ix, self.opid, self.op2_ix, self.timer_ix, self.ctr_ix, self.num]
         # @tbd: check if time ops have been set and tokenize accordingly
     
     def add_op_tokens(self):
@@ -140,13 +148,13 @@ def step_special_action(op, state_ix, dict_ix, step):
     ix2 = op[4]
     tix = op[5] # which slot is the time comparison in?
     if (tix in state_ix and step < state_ix[tix]):
-        return False
+        return
     ctr_ix = op[6] # id of the counter variable
     num_ix = op[7] # max times to complete
     num_done = state_ix[ctr_ix]
     num = state_ix[num_ix] # num to complete
     if (tix in state_ix and num_done >= num):
-       return False
+       return
     else:
         if sop == 1:
             result = state_ix[ix2]

--- a/HSP2/state.py
+++ b/HSP2/state.py
@@ -29,14 +29,6 @@ def init_state_dicts():
     return state
 
 
-def find_state_path(state_paths, parent_path, varname):
-    """
-    We should get really good at using docstrings...
-    """
-    # this is a bandaid, we should have an object routine that searches the parent for variables or inputs
-    var_path = parent_path + "/states/" + str(varname)
-    return var_path
-
 def op_path_name(operation, id):
     """
     Used to generate hdf5 operation name in a central fashion to avoid naming convention slip-ups
@@ -125,7 +117,15 @@ def state_context_hsp2(state, operation, segment, activity):
     state['segment'] = segment # 
     state['activity'] = activity
     # give shortcut to state path for the upcoming function 
-    state['domain'] = "/STATE/" + operation + "_" + segment # + "/" + activity   # may want to comment out activity?
+    # insure that there is a model object container
+    seg_name = operation + "_" + segment 
+    seg_path =  '/STATE/' + seg_name
+    if 'hsp_segments' not in state.keys():
+        state['hsp_segments'] = {} # for later use by things that need to know hsp entities and their paths
+    if seg_name not in state['hsp_segments'].keys():
+        state['hsp_segments'][seg_name] = seg_path
+
+    state['domain'] = seg_path # + "/" + activity   # may want to comment out activity?
 
 def state_siminfo_hsp2(uci_obj, siminfo):
     # Add crucial simulation info for dynamic operation support
@@ -133,6 +133,19 @@ def state_siminfo_hsp2(uci_obj, siminfo):
     siminfo['delt'] = delt
     siminfo['tindex'] = date_range(siminfo['start'], siminfo['stop'], freq=Minute(delt))[1:]
     siminfo['steps'] = len(siminfo['tindex'])
+
+def state_init_hsp2(state, opseq, activities):
+    # This sets up the state entries for all state compatible HSP2 model variables
+    for _, operation, segment, delt in opseq.itertuples():
+        if operation != 'GENER' and operation != 'COPY':
+            for activity, function in activities[operation].items():
+                if activity == 'HYDR':
+                    state_context_hsp2(state, operation, segment, activity)
+                    print("Init HYDR state context for domain", state['domain'])
+                    hydr_init_ix(state, state['domain'])
+                elif activity == 'SEDTRN':
+                    state_context_hsp2(state, operation, segment, activity)
+                    sedtrn_init_ix(state, state['domain'])
 
 def state_load_hdf5_components(io_manager, siminfo, op_tokens, state_paths, state_ix, dict_ix, ts_ix, model_object_cache):
     # Implement population of model_object_cache etc from components in a hdf5 such as Special ACTIONS
@@ -145,24 +158,24 @@ def state_load_dynamics_hsp2(state, io_manager, siminfo):
     state['state_step_hydr'] = siminfo['state_step_hydr'] # enabled or disabled 
     state['hsp2_local_py'] = hsp2_local_py # Stores the actual function in state
 
-def hydr_init_ix(state_ix, state_paths, domain):
+def hydr_init_ix(state, domain):
     # get a list of keys for all hydr state variables
     hydr_state = ["DEP","IVOL","O1","O2","O3","OVOL1","OVOL2","OVOL3","PRSUPY","RO","ROVOL","SAREA","TAU","USTAR","VOL","VOLEV"]
     hydr_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in hydr_state:
         #var_path = f'{domain}/{i}'
         var_path = domain + "/" + i
-        hydr_ix[i] = set_state(state_ix, state_paths, var_path, 0.0)
+        hydr_ix[i] = set_state(state['state_ix'], state['state_paths'], var_path, 0.0)
     return hydr_ix
 
-def sedtrn_init_ix(state_ix, state_paths, domain):
+def sedtrn_init_ix(state, domain):
     # get a list of keys for all sedtrn state variables
     sedtrn_state = ["RSED4","RSED5","RSED6"]
     sedtrn_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in sedtrn_state:
         #var_path = f'{domain}/{i}'
         var_path = domain + "/" + i
-        sedtrn_ix[i] = set_state(state_ix, state_paths, var_path, 0.0)
+        sedtrn_ix[i] = set_state(state['state_ix'], state['state_paths'], var_path, 0.0)
     return sedtrn_ix
     
 @njit
@@ -176,6 +189,7 @@ def hydr_get_ix(state_ix, state_paths, domain):
         hydr_ix[i] = state_paths[var_path]
     return hydr_ix    
 
+@njit
 def sedtrn_get_ix(state_ix, state_paths, domain):
     # get a list of keys for all sedtrn state variables
     sedtrn_state = ["RSED4", "RSED5", "RSED6"]

--- a/tests/test10/HSP2results/test10.uci
+++ b/tests/test10/HSP2results/test10.uci
@@ -991,4 +991,12 @@ GENER    2 OUTPUT TIMSER          1.1      DISPLY   4     INPUT  TIMSER
 RCHRES   5 HYDR   ROVOL          12.1      PLTGEN   1     INPUT  MEAN   2
 END NETWORK
 
+SPEC-ACTIONS
+*** test special actions
+  RCHRES 5                                RSED    4       +=  2.50E+05
+  RCHRES 5                                RSED    5       +=  6.89E+05
+  RCHRES 5                                RSED    6       +=  4.01E+05
+END SPEC-ACTIONS
+
+
 END RUN

--- a/tests/testcbp/HSP2results/check_depends_endpoint.py
+++ b/tests/testcbp/HSP2results/check_depends_endpoint.py
@@ -1,0 +1,75 @@
+# bare bones tester - must be run from the HSPsquared source directory
+import os
+from HSP2.main import *
+from HSP2.om import *
+import HSP2IO
+import numpy
+from HSP2IO.hdf import HDF5
+from HSP2IO.io import IOManager
+fpath = './tests/test10/HSP2results/test10.h5' 
+# try also:
+# fpath = './tests/testcbp/HSP2results/PL3_5250_0001.h5' 
+# sometimes when testing you may need to close the file, so try:
+# f = h5py.File(fpath,'a') # use mode 'a' which allows read, write, modify
+# # f.close()
+hdf5_instance = HDF5(fpath)
+io_manager = IOManager(hdf5_instance)
+uci_obj = io_manager.read_uci()
+siminfo = uci_obj.siminfo
+opseq = uci_obj.opseq
+# - finally stash specactions in state, not domain (segment) dependent so do it once
+# now load state and the special actions
+state = init_state_dicts()
+state_initialize_om(state)
+state['specactions'] = uci_obj.specactions # stash the specaction dict in state
+
+state_siminfo_hsp2(uci_obj, siminfo)
+# Add support for dynamic functions to operate on STATE
+# - Load any dynamic components if present, and store variables on objects 
+state_load_dynamics_hsp2(state, io_manager, siminfo)
+# Iterate through all segments and add crucial paths to state 
+# before loading dynamic components that may reference them
+state_init_hsp2(state, opseq, activities)
+state_load_dynamics_specl(state, io_manager, siminfo) # traditional special actions
+state_load_dynamics_om(state, io_manager, siminfo) # operational model for custom python
+state_om_model_run_prep(state, io_manager, siminfo) # this creates all objects from the UCI and previous loads
+# state['model_root_object'].find_var_path('RCHRES_R001')
+
+
+model_order_recursive(specl2, state['model_object_cache'], mel, mtl)
+def mel_path(mel, state):
+    ixn = 1
+    for ix in mel:
+        ip = get_ix_path(state['state_paths'], ix)
+        im = state['model_object_cache'][ip]
+        print(ixn, ":", im.name, "->", im.state_path, '=', im.get_state())
+        ixn = ixn + 1
+    return
+
+# Show order of ops based on dependencies
+endpoint = state['model_object_cache']['/STATE/RCHRES_R005/RSED5']
+mel = []
+mtl = []
+model_order_recursive(endpoint, state['model_object_cache'], mel, mtl)
+print("Dependency ordered execution for constants and runnables influencing", endpoint.name)
+mel_path(mel, state)
+mel_runnable = ModelObject.runnable_op_list(state['op_tokens'], mel)
+print("Dependency ordered execution of runnables only for", endpoint.name)
+mel_path(mel_runnable, state)
+
+# Aggregate the list of all SEDTRN end point dependencies
+domain = '/STATE/RCHRES_R005'
+ep_list = ['RSED4', 'RSED5', 'RSED6']
+mello = model_domain_dependencies(state, domain, ep_list)
+print("Dependency ordered execution for RSED constants and runnables influencing", domain, "=", mello)
+mel_runnable = ModelObject.runnable_op_list(state['op_tokens'], mello)
+print("Dependency ordered execution of RSED runnables only for", domain, "=", mel_runnable)
+
+# Just for grins, we can show the dependency using the special action as an end point
+specl2 = state['model_object_cache']['/STATE/SPECACTION2']
+mel = []
+mtl = []
+print("Dependency ordered execution for constants and runnables influencing ", rsed4.name)
+model_order_recursive(specl2, state['model_object_cache'], mel, mtl)
+mel_path(mel, state)
+mel_runnable = ModelObject.runnable_op_list(state['op_tokens'], mel)


### PR DESCRIPTION
@PaulDudaRESPEC 
This push has 12 file changes in here, which look a bit voluminous, but the reality is that:
- `om.py` - added function to do dependency ordering for a given domain, i.e., `model_domain_dependencies()`, and tidied up some variable creation routines.
- 2 Are clean-up, removing "test" functions, and old debug print statement, etc:
   - `.gitignore` (add test h5s), 
   - `SPECL.py` (remove prints), 
- `main.py` - functionalized a block of code that sets up STATE variables for eligible domain variables (like `HYDR` and `SEDTRN`), and called new functions to take their place.
- `SEDTRN.py`
   - SEDTRN now has the first implementation of the "domain dependency order", so that only those operational components affecting SEDTRN related variables are executed.  
   - A test script for this functionality is included at #133 so that you can see the ordering (this code is also located in `tests/testcbp/HSP2Results/check_depends_endpoint.py`.
- `test10.uci` -  This UCI (based on our email exchange) has 3 SPEC-ACTIONS all pointing at a single reach (RCHRES 5), and thus, only 3 operational model components are executed during the SEDTRN pass through RCHRES 5, and ignored during other
- 