### PR TITLE
Fixed versions in develop mode; Module docstrings; More Env Improvements

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,6 +1,0 @@
-import os
-
-with open(
-    os.path.join(os.path.dirname(__file__), "VERSION"), encoding="ascii"
-) as version_file:
-    __version__ = version_file.read().strip()

--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,13 @@
 ---
-name: hsp2_py310
+name: hsp2
 channels:
   - conda-forge
   - nodefaults  # Speeds solving env, by limiting the number of options
 
 dependencies:
-  # Python 3.10 was default for Anaconda 2023.03-0 (Mar 20, 2023)
-  # https://docs.anaconda.com/free/anaconda/release-notes/#anaconda-2023-03-0-mar-20-2023
-  # package management
-  - conda
-  - conda-build
-  - conda-libmamba-solver
-  - pip
+  - python >=3.10
 
   # Running HSP2
-  - python =3.10
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
   - pandas
@@ -29,21 +22,27 @@ dependencies:
   # Operational Model (om)
   - pyparsing
 
-  # Interactivity & Visualization via Jupyter Notebooks (optional,
-  # but required for tutorials)
+  # Interactivity via Jupyter Notebooks (optional, but required for tutorials)
   - jupyterlab  # also installs classic Jupyter notbook
-  - ipympl  # jupyter-matplotlib, https://github.com/matplotlib/ipympl
   - nodejs  # required for many JupyterLab extensions
-  # HoloViz, https://holoviz.org
+
+  # Visualization (optional)
   - hvplot  # hvPlot installs most HoloViz libs, including matplotlib
+  - ipympl  # jupyter-matplotlib, https://github.com/matplotlib/ipympl
   - ipywidgets  # Required for HoloViz interactivity in Jupyter notebooks
   - ipywidgets_bokeh
-  - jupyter_bokeh # for VSCode
+  - jupyter_bokeh # Renders Holviz / Bokeh objects in Jupyter
+  - pyviz_comms # bidirectional communication between Python & JavaScript for Jupyter
 
   # Dev tools (optional)
-  - python-lsp-server # Language Server Protocol (LSP) extension for Python (pylsp)
+    # Language Server Protocol (LSP) extension for Python (pylsp)
+  - python-lsp-server
   - jupyterlab-lsp # Provides both server extension and lab extension
 
+  # Environment and package management
+  - conda
+  - conda-libmamba-solver
+  - pip
   # PIP install requirements only if it is not possible with conda
   # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment
   - pip:

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -6,15 +6,10 @@ channels:
 
 dependencies:
   # Python 3.11 was default for Anaconda 2023.07-0 (Jul 11, 2023)
-  # https://docs.anaconda.com/free/anaconda/release-notes/#anaconda-2023-03-0-mar-20-2023
-  # package management
-  - conda
-  - conda-build
-  - conda-libmamba-solver
-  - pip
+  # https://docs.anaconda.com/anaconda/release-notes/#anaconda-2023-07-0-jul-11-2023
+  - python =3.11
 
   # Running HSP2
-  - python =3.11
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
   - pandas >=2.0
@@ -30,16 +25,17 @@ dependencies:
   # Operational Model (om)
   - pyparsing
 
-  # Interactivity & Visualization via Jupyter Notebooks (optional,
-  # but required for tutorials)
+  # Interactivity via Jupyter Notebooks (optional, but required for tutorials)
   - jupyterlab  # also installs classic Jupyter notbook
-  - ipympl  # jupyter-matplotlib, https://github.com/matplotlib/ipympl
   - nodejs  # required for many JupyterLab extensions
-  # HoloViz, https://holoviz.org
+
+  # Visualization (optional)
   - hvplot  # hvPlot installs most HoloViz libs, including matplotlib
+  - ipympl  # jupyter-matplotlib, https://github.com/matplotlib/ipympl
   - ipywidgets  # Required for HoloViz interactivity in Jupyter notebooks
   - ipywidgets_bokeh
-  - jupyter_bokeh # for VSCode
+  - jupyter_bokeh # Renders Holviz / Bokeh objects in Jupyter
+  - pyviz_comms # bidirectional communication between Python & JavaScript for Jupyter
 
   # Dev tools (optional)
   # Language Server Protocol (LSP) extension for Python (pylsp)
@@ -53,10 +49,14 @@ dependencies:
     # YAPF for code formatting (preferred over autopep8)
     # flake8 for error checking (disabled by default)
     # pylint for code linting (disabled by default)
-  - jupyterlab-lsp  # Provides both server extension and lab extension
+  - jupyterlab-lsp # Provides both server extension and lab extension
 
-
+  # Environment and package management
+  - conda
+  - conda-build
+  - conda-libmamba-solver
+  - pip
   # PIP install requirements only if it is not possible with conda
   # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment
   - pip:
-    # For Dev environment, we recommend using the `conda build` command to install
+    # For developing HPS2, we recommend using the `conda build` command to "install"

--- a/examples/1_Intro_to_HSP2.ipynb
+++ b/examples/1_Intro_to_HSP2.ipynb
@@ -90,7 +90,7 @@
     {
      "data": {
       "text/plain": [
-       "'hsp2_py310'"
+       "'hsp2'"
       ]
      },
      "execution_count": 2,
@@ -244,7 +244,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>Python</th>\n",
-       "      <td>3.10.16 | packaged by conda-forge | (main, Dec...</td>\n",
+       "      <td>3.12.8 | packaged by conda-forge | (main, Dec ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>hsp2</th>\n",
@@ -252,7 +252,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>numpy</th>\n",
-       "      <td>1.26.4</td>\n",
+       "      <td>2.0.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>numba</th>\n",
@@ -260,11 +260,11 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>pandas</th>\n",
-       "      <td>2.0.0</td>\n",
+       "      <td>2.2.3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>matplotlib</th>\n",
-       "      <td>3.9.4</td>\n",
+       "      <td>3.10.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>tables</th>\n",
@@ -284,7 +284,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Date/Time</th>\n",
-       "      <td>2024-12-16T14:54:23.519387</td>\n",
+       "      <td>2024-12-17T10:48:52.834595</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -293,17 +293,17 @@
       "text/plain": [
        "                                                      version\n",
        "name                                                         \n",
-       "Python      3.10.16 | packaged by conda-forge | (main, Dec...\n",
+       "Python      3.12.8 | packaged by conda-forge | (main, Dec ...\n",
        "hsp2                                                      n/a\n",
-       "numpy                                                  1.26.4\n",
+       "numpy                                                   2.0.2\n",
        "numba                                                  0.60.0\n",
-       "pandas                                                  2.0.0\n",
-       "matplotlib                                              3.9.4\n",
+       "pandas                                                  2.2.3\n",
+       "matplotlib                                             3.10.0\n",
        "tables                                                 3.10.1\n",
        "h5py                                                   3.12.1\n",
        "os                               macOS-14.7.1-arm64-arm-64bit\n",
        "processor                                                 arm\n",
-       "Date/Time                          2024-12-16T14:54:23.519387"
+       "Date/Time                          2024-12-17T10:48:52.834595"
       ]
      },
      "execution_count": 7,
@@ -318,15 +318,55 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternate ways to get the HSP2 version:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Built in approach, that will work with next release\n",
+    "# hsp2.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.11.0a1'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# From PyPI Package\n",
+    "# NOTE: this won't work when in `conda develop` mode.\n",
+    "from importlib.metadata import version\n",
+    "version('hsp2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "# packages in environment at /Users/aaufdenkampe/miniconda3/envs/hsp2_py310:\n",
+      "# packages in environment at /Users/aaufdenkampe/miniconda3/envs/hsp2:\n",
       "#\n",
       "# Name                    Version                   Build  Channel\n",
       "hsp2                      0.11.0a1                 pypi_0    pypi\n"
@@ -334,6 +374,7 @@
     }
    ],
    "source": [
+    "# From conda magic command\n",
     "!conda list hsp2"
    ]
   },
@@ -348,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2024-05-21T17:40:36.407261Z",
@@ -365,7 +406,7 @@
        "PosixPath('/Users/aaufdenkampe/Documents/Python/respec.HSPsquared')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -388,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2024-05-21T18:52:11.477985Z",
@@ -443,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2024-05-21T17:40:42.208083Z",
@@ -474,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2024-05-21T17:40:43.187481Z",
@@ -490,7 +531,7 @@
      "output_type": "stream",
      "text": [
       "/Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5\n",
-      "File exists? False\n"
+      "File exists? True\n"
      ]
     }
    ],
@@ -533,15 +574,159 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2tools/readUCI.py:102: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_numeric without passing `errors` and catch exceptions explicitly instead\n",
+      "  df = df.apply(pd.to_numeric, errors='ignore') # todo: 'ignore' is deprecated.\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.19 s, sys: 314 ms, total: 6.5 s\n",
-      "Wall time: 6.58 s\n"
+      "CPU times: user 5.91 s, sys: 340 ms, total: 6.25 s\n",
+      "Wall time: 6.31 s\n"
      ]
     }
    ],
@@ -557,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -575,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -601,8 +786,8 @@
       "135 reading from wdm\n",
       "136 reading from wdm\n",
       "140 reading from wdm\n",
-      "CPU times: user 1.45 s, sys: 66.3 ms, total: 1.52 s\n",
-      "Wall time: 1.74 s\n"
+      "CPU times: user 1.26 s, sys: 201 ms, total: 1.46 s\n",
+      "Wall time: 17.5 s\n"
      ]
     },
     {
@@ -851,8 +1036,8 @@
        "</div>"
       ],
       "text/plain": [
-       "                     Start                 Stop Freq  Length TSTYPE  TFILL   \n",
-       "TS039  1976-01-01 00:00:00  1977-01-01 00:00:00   1h    8784   PREC -999.0  \\\n",
+       "                     Start                 Stop Freq  Length TSTYPE  TFILL  \\\n",
+       "TS039  1976-01-01 00:00:00  1977-01-01 00:00:00   1h    8784   PREC -999.0   \n",
        "TS041  1976-01-01 00:00:00  1977-01-01 00:00:00   1D     366   EVAP -999.0   \n",
        "TS042  1976-01-01 00:00:00  1977-01-01 00:00:00   1D     366   WIND -999.0   \n",
        "TS046  1976-01-01 00:00:00  1977-01-01 00:00:00   2h    4392   SOLR -999.0   \n",
@@ -894,7 +1079,7 @@
        "TS140           COLIND  COLUMN INDICATOR MEIER POND SUMMER-WINTER OUTLET  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -934,16 +1119,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<hsp2.hsp2io.hdf.HDF5 at 0x30ed47790>"
+       "<hsp2.hsp2io.hdf.HDF5 at 0x30e77b4a0>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -957,7 +1142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -966,7 +1151,7 @@
        "['/Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -981,16 +1166,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<hsp2.hsp2io.io.IOManager at 0x30ed47c40>"
+       "<hsp2.hsp2io.io.IOManager at 0x30e72fe60>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1005,7 +1190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1013,8 +1198,8 @@
      "output_type": "stream",
      "text": [
       "\u001b[0;31mType:\u001b[0m           IOManager\n",
-      "\u001b[0;31mString form:\u001b[0m    <hsp2.hsp2io.io.IOManager object at 0x30ed47c40>\n",
-      "\u001b[0;31mFile:\u001b[0m           ~/miniconda3/envs/hsp2_py310/lib/python3.10/site-packages/hsp2/hsp2io/io.py\n",
+      "\u001b[0;31mString form:\u001b[0m    <hsp2.hsp2io.io.IOManager object at 0x30e72fe60>\n",
+      "\u001b[0;31mFile:\u001b[0m           ~/miniconda3/envs/hsp2/lib/python3.12/site-packages/hsp2/hsp2io/io.py\n",
       "\u001b[0;31mDocstring:\u001b[0m      Management class for IO operations needed to execute the HSP2 model\n",
       "\u001b[0;31mInit docstring:\u001b[0m\n",
       "io_combined: SupportsReadUCI & SupportsReadTS & SupportsWriteTS & SupportsWriteLogging / None\n",
@@ -1066,92 +1251,92 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-12-16 14:54:31.88   Processing started for file /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5; saveall=False\n",
-      "2024-12-16 14:54:36.00   Simulation Start: 1976-01-01 00:00:00, Stop: 1977-01-01 00:00:00\n",
-      "2024-12-16 14:54:36.01      PERLND P001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:36.30         SNOW\n",
-      "2024-12-16 14:54:36.83         PWATER\n",
-      "2024-12-16 14:54:37.04         PSTEMP\n",
-      "2024-12-16 14:54:37.05         PWTGAS\n",
-      "2024-12-16 14:54:37.06      RCHRES R001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:37.07         HYDR\n",
-      "2024-12-16 14:54:41.33         ADCALC\n",
-      "2024-12-16 14:54:41.35         CONS\n",
-      "2024-12-16 14:54:41.39         HTRCH\n",
-      "2024-12-16 14:54:41.41         SEDTRN\n",
-      "2024-12-16 14:54:41.43         RQUAL\n",
-      "2024-12-16 14:54:41.78         GQUAL\n",
-      "2024-12-16 14:54:42.32      GENER G001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:42.32      RCHRES R002 DELT(minutes): 60\n",
-      "2024-12-16 14:54:42.33         HYDR\n",
-      "2024-12-16 14:54:44.85         ADCALC\n",
-      "2024-12-16 14:54:44.85         CONS\n",
-      "2024-12-16 14:54:44.86         HTRCH\n",
-      "2024-12-16 14:54:44.86            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:44.86         SEDTRN\n",
-      "2024-12-16 14:54:44.87            Error count 3598: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:44.87         RQUAL\n",
-      "2024-12-16 14:54:45.02         GQUAL\n",
-      "2024-12-16 14:54:45.32      RCHRES R003 DELT(minutes): 60\n",
-      "2024-12-16 14:54:45.33         HYDR\n",
-      "2024-12-16 14:54:45.35         ADCALC\n",
-      "2024-12-16 14:54:45.35         CONS\n",
-      "2024-12-16 14:54:45.36         HTRCH\n",
-      "2024-12-16 14:54:45.36            Error count 3: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:45.36         SEDTRN\n",
-      "2024-12-16 14:54:45.37            Error count 513: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:45.37         RQUAL\n",
-      "2024-12-16 14:54:45.50         GQUAL\n",
-      "2024-12-16 14:54:45.73      RCHRES R004 DELT(minutes): 60\n",
-      "2024-12-16 14:54:45.76         HYDR\n",
-      "2024-12-16 14:54:45.78         ADCALC\n",
-      "2024-12-16 14:54:45.79         CONS\n",
-      "2024-12-16 14:54:45.79         HTRCH\n",
-      "2024-12-16 14:54:45.79            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:45.80         SEDTRN\n",
-      "2024-12-16 14:54:45.80            Error count 6720: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:45.81         RQUAL\n",
-      "2024-12-16 14:54:45.95         GQUAL\n",
-      "2024-12-16 14:54:46.31      IMPLND I001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:46.31         SNOW\n",
-      "2024-12-16 14:54:46.36         IWATER\n",
-      "2024-12-16 14:54:46.38         SOLIDS\n",
-      "2024-12-16 14:54:46.39         IWTGAS\n",
-      "2024-12-16 14:54:46.39         IQUAL\n",
-      "2024-12-16 14:54:46.40      RCHRES R005 DELT(minutes): 60\n",
-      "2024-12-16 14:54:46.41         HYDR\n",
-      "2024-12-16 14:54:46.43         ADCALC\n",
-      "2024-12-16 14:54:46.43         CONS\n",
-      "2024-12-16 14:54:46.44         HTRCH\n",
-      "2024-12-16 14:54:46.44            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:46.44         SEDTRN\n",
-      "2024-12-16 14:54:46.45         RQUAL\n",
-      "2024-12-16 14:54:46.60         GQUAL\n",
-      "2024-12-16 14:54:46.97      GENER G002 DELT(minutes): 60\n",
-      "2024-12-16 14:54:46.97   Done; Run time is about 00:15.0 (mm:ss)\n",
+      "2024-12-17 10:49:30.22   Processing started for file /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5; saveall=False\n",
+      "2024-12-17 10:49:33.79   Simulation Start: 1976-01-01 00:00:00, Stop: 1977-01-01 00:00:00\n",
+      "2024-12-17 10:49:33.79      PERLND P001 DELT(minutes): 60\n",
+      "2024-12-17 10:49:34.03         SNOW\n",
+      "2024-12-17 10:49:35.97         PWATER\n",
+      "2024-12-17 10:49:37.89         PSTEMP\n",
+      "2024-12-17 10:49:38.21         PWTGAS\n",
+      "2024-12-17 10:49:39.04      RCHRES R001 DELT(minutes): 60\n",
+      "2024-12-17 10:49:39.05         HYDR\n",
+      "2024-12-17 10:49:42.82         ADCALC\n",
+      "2024-12-17 10:49:43.26         CONS\n",
+      "2024-12-17 10:49:43.76         HTRCH\n",
+      "2024-12-17 10:49:44.82         SEDTRN\n",
+      "2024-12-17 10:49:49.95         RQUAL\n",
+      "2024-12-17 10:50:11.12         GQUAL\n",
+      "2024-12-17 10:50:12.40      GENER G001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:12.40      RCHRES R002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:12.41         HYDR\n",
+      "2024-12-17 10:50:14.50         ADCALC\n",
+      "2024-12-17 10:50:14.51         CONS\n",
+      "2024-12-17 10:50:14.51         HTRCH\n",
+      "2024-12-17 10:50:14.51            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:14.51         SEDTRN\n",
+      "2024-12-17 10:50:14.52            Error count 3598: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:14.52         RQUAL\n",
+      "2024-12-17 10:50:14.66         GQUAL\n",
+      "2024-12-17 10:50:14.96      RCHRES R003 DELT(minutes): 60\n",
+      "2024-12-17 10:50:14.96         HYDR\n",
+      "2024-12-17 10:50:14.98         ADCALC\n",
+      "2024-12-17 10:50:14.98         CONS\n",
+      "2024-12-17 10:50:14.99         HTRCH\n",
+      "2024-12-17 10:50:14.99            Error count 3: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:14.99         SEDTRN\n",
+      "2024-12-17 10:50:15.00            Error count 513: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:15.00         RQUAL\n",
+      "2024-12-17 10:50:15.13         GQUAL\n",
+      "2024-12-17 10:50:15.36      RCHRES R004 DELT(minutes): 60\n",
+      "2024-12-17 10:50:15.38         HYDR\n",
+      "2024-12-17 10:50:15.40         ADCALC\n",
+      "2024-12-17 10:50:15.40         CONS\n",
+      "2024-12-17 10:50:15.40         HTRCH\n",
+      "2024-12-17 10:50:15.40            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:15.41         SEDTRN\n",
+      "2024-12-17 10:50:15.42            Error count 6720: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:15.42         RQUAL\n",
+      "2024-12-17 10:50:15.55         GQUAL\n",
+      "2024-12-17 10:50:15.88      IMPLND I001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:15.89         SNOW\n",
+      "2024-12-17 10:50:15.93         IWATER\n",
+      "2024-12-17 10:50:16.61         SOLIDS\n",
+      "2024-12-17 10:50:16.83         IWTGAS\n",
+      "2024-12-17 10:50:17.12         IQUAL\n",
+      "2024-12-17 10:50:17.58      RCHRES R005 DELT(minutes): 60\n",
+      "2024-12-17 10:50:17.59         HYDR\n",
+      "2024-12-17 10:50:17.61         ADCALC\n",
+      "2024-12-17 10:50:17.61         CONS\n",
+      "2024-12-17 10:50:17.61         HTRCH\n",
+      "2024-12-17 10:50:17.61            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:17.62         SEDTRN\n",
+      "2024-12-17 10:50:17.63         RQUAL\n",
+      "2024-12-17 10:50:17.77         GQUAL\n",
+      "2024-12-17 10:50:18.09      GENER G002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:18.10   Done; Run time is about 00:47.8 (mm:ss)\n",
       "\n",
       "\n",
       "                                                       version\n",
       "name                                                         \n",
-      "Python      3.10.16 | packaged by conda-forge | (main, Dec...\n",
+      "Python      3.12.8 | packaged by conda-forge | (main, Dec ...\n",
       "hsp2                                                      n/a\n",
-      "numpy                                                  1.26.4\n",
+      "numpy                                                   2.0.2\n",
       "numba                                                  0.60.0\n",
-      "pandas                                                  2.0.0\n",
+      "pandas                                                  2.2.3\n",
       "jupyterlab                                              4.3.3\n",
       "notebook                                                  n/a\n",
       "os                               macOS-14.7.1-arm64-arm-64bit\n",
       "processor                                                 arm\n",
-      "Date/Time                          2024-12-16T14:54:47.418260\n",
-      "CPU times: user 14.7 s, sys: 428 ms, total: 15.1 s\n",
-      "Wall time: 15.5 s\n"
+      "Date/Time                          2024-12-17T10:50:22.776259\n",
+      "CPU times: user 46.4 s, sys: 1.27 s, total: 47.6 s\n",
+      "Wall time: 52.6 s\n"
      ]
     }
    ],
@@ -1182,6 +1367,103 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-12-17 10:50:22.79   Processing started for file /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5; saveall=False\n",
+      "2024-12-17 10:50:24.99   Simulation Start: 1976-01-01 00:00:00, Stop: 1977-01-01 00:00:00\n",
+      "2024-12-17 10:50:24.99      PERLND P001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:24.99         SNOW\n",
+      "2024-12-17 10:50:25.04         PWATER\n",
+      "2024-12-17 10:50:25.08         PSTEMP\n",
+      "2024-12-17 10:50:25.08         PWTGAS\n",
+      "2024-12-17 10:50:25.09      RCHRES R001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:25.09         HYDR\n",
+      "2024-12-17 10:50:25.12         ADCALC\n",
+      "2024-12-17 10:50:25.12         CONS\n",
+      "2024-12-17 10:50:25.13         HTRCH\n",
+      "2024-12-17 10:50:25.13         SEDTRN\n",
+      "2024-12-17 10:50:25.14         RQUAL\n",
+      "2024-12-17 10:50:25.47         GQUAL\n",
+      "2024-12-17 10:50:25.94      GENER G001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:25.94      RCHRES R002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:25.95         HYDR\n",
+      "2024-12-17 10:50:25.97         ADCALC\n",
+      "2024-12-17 10:50:25.97         CONS\n",
+      "2024-12-17 10:50:25.97         HTRCH\n",
+      "2024-12-17 10:50:25.98            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:25.98         SEDTRN\n",
+      "2024-12-17 10:50:25.98            Error count 3598: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:25.99         RQUAL\n",
+      "2024-12-17 10:50:26.13         GQUAL\n",
+      "2024-12-17 10:50:26.42      RCHRES R003 DELT(minutes): 60\n",
+      "2024-12-17 10:50:26.43         HYDR\n",
+      "2024-12-17 10:50:26.45         ADCALC\n",
+      "2024-12-17 10:50:26.45         CONS\n",
+      "2024-12-17 10:50:26.46         HTRCH\n",
+      "2024-12-17 10:50:26.46            Error count 3: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:26.46         SEDTRN\n",
+      "2024-12-17 10:50:26.47            Error count 513: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:26.47         RQUAL\n",
+      "2024-12-17 10:50:26.61         GQUAL\n",
+      "2024-12-17 10:50:26.84      RCHRES R004 DELT(minutes): 60\n",
+      "2024-12-17 10:50:26.85         HYDR\n",
+      "2024-12-17 10:50:26.87         ADCALC\n",
+      "2024-12-17 10:50:26.87         CONS\n",
+      "2024-12-17 10:50:26.88         HTRCH\n",
+      "2024-12-17 10:50:26.88            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:26.88         SEDTRN\n",
+      "2024-12-17 10:50:26.89            Error count 6720: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:26.89         RQUAL\n",
+      "2024-12-17 10:50:27.05         GQUAL\n",
+      "2024-12-17 10:50:27.38      IMPLND I001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:27.38         SNOW\n",
+      "2024-12-17 10:50:27.43         IWATER\n",
+      "2024-12-17 10:50:27.45         SOLIDS\n",
+      "2024-12-17 10:50:27.45         IWTGAS\n",
+      "2024-12-17 10:50:27.45         IQUAL\n",
+      "2024-12-17 10:50:27.46      RCHRES R005 DELT(minutes): 60\n",
+      "2024-12-17 10:50:27.46         HYDR\n",
+      "2024-12-17 10:50:27.49         ADCALC\n",
+      "2024-12-17 10:50:27.49         CONS\n",
+      "2024-12-17 10:50:27.49         HTRCH\n",
+      "2024-12-17 10:50:27.49            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:27.49         SEDTRN\n",
+      "2024-12-17 10:50:27.50         RQUAL\n",
+      "2024-12-17 10:50:27.67         GQUAL\n",
+      "2024-12-17 10:50:28.00      GENER G002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:28.00   Done; Run time is about 00:05.2 (mm:ss)\n",
+      "\n",
+      "\n",
+      "                                                       version\n",
+      "name                                                         \n",
+      "Python      3.12.8 | packaged by conda-forge | (main, Dec ...\n",
+      "hsp2                                                      n/a\n",
+      "numpy                                                   2.0.2\n",
+      "numba                                                  0.60.0\n",
+      "pandas                                                  2.2.3\n",
+      "jupyterlab                                              4.3.3\n",
+      "notebook                                                  n/a\n",
+      "os                               macOS-14.7.1-arm64-arm-64bit\n",
+      "processor                                                 arm\n",
+      "Date/Time                          2024-12-17T10:50:28.014884\n",
+      "CPU times: user 4.95 s, sys: 219 ms, total: 5.17 s\n",
+      "Wall time: 5.23 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# This model should now take <1 minute to run, now that it has already compiled\n",
+    "hsp2.main(io_manager, saveall=False)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1193,7 +1475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1202,7 +1484,7 @@
        "['/Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1214,7 +1496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1224,7 +1506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1242,7 +1524,7 @@
        "['/Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5']"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1254,14 +1536,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/aaufdenkampe/miniconda3/envs/hsp2_py310/lib/python3.10/site-packages/tables/file.py:114: UnclosedFileWarning: Closing remaining open file: /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5\n",
+      "/Users/aaufdenkampe/miniconda3/envs/hsp2/lib/python3.12/site-packages/tables/file.py:114: UnclosedFileWarning: Closing remaining open file: /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5\n",
       "  warnings.warn(UnclosedFileWarning(msg))\n"
      ]
     }
@@ -1273,7 +1555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1282,7 +1564,7 @@
        "[]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1306,92 +1588,92 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-12-16 14:54:47.46   Processing started for file /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5; saveall=True\n",
-      "2024-12-16 14:54:49.73   Simulation Start: 1976-01-01 00:00:00, Stop: 1977-01-01 00:00:00\n",
-      "2024-12-16 14:54:49.73      PERLND P001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:49.76         SNOW\n",
-      "2024-12-16 14:54:49.83         PWATER\n",
-      "2024-12-16 14:54:49.94         PSTEMP\n",
-      "2024-12-16 14:54:49.96         PWTGAS\n",
-      "2024-12-16 14:54:50.03      RCHRES R001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:50.04         HYDR\n",
-      "2024-12-16 14:54:50.11         ADCALC\n",
-      "2024-12-16 14:54:50.11         CONS\n",
-      "2024-12-16 14:54:50.14         HTRCH\n",
-      "2024-12-16 14:54:50.19         SEDTRN\n",
-      "2024-12-16 14:54:50.30         RQUAL\n",
-      "2024-12-16 14:54:51.13         GQUAL\n",
-      "2024-12-16 14:54:51.85      GENER G001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:51.85      RCHRES R002 DELT(minutes): 60\n",
-      "2024-12-16 14:54:51.86         HYDR\n",
-      "2024-12-16 14:54:51.91         ADCALC\n",
-      "2024-12-16 14:54:51.92         CONS\n",
-      "2024-12-16 14:54:51.94         HTRCH\n",
-      "2024-12-16 14:54:51.94            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:51.98         SEDTRN\n",
-      "2024-12-16 14:54:51.99            Error count 3598: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:52.07         RQUAL\n",
-      "2024-12-16 14:54:52.63         GQUAL\n",
-      "2024-12-16 14:54:53.11      RCHRES R003 DELT(minutes): 60\n",
-      "2024-12-16 14:54:53.13         HYDR\n",
-      "2024-12-16 14:54:53.18         ADCALC\n",
-      "2024-12-16 14:54:53.18         CONS\n",
-      "2024-12-16 14:54:53.20         HTRCH\n",
-      "2024-12-16 14:54:53.20            Error count 3: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:53.24         SEDTRN\n",
-      "2024-12-16 14:54:53.24            Error count 513: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:53.32         RQUAL\n",
-      "2024-12-16 14:54:53.85         GQUAL\n",
-      "2024-12-16 14:54:54.24      RCHRES R004 DELT(minutes): 60\n",
-      "2024-12-16 14:54:54.26         HYDR\n",
-      "2024-12-16 14:54:54.32         ADCALC\n",
-      "2024-12-16 14:54:54.32         CONS\n",
-      "2024-12-16 14:54:54.35         HTRCH\n",
-      "2024-12-16 14:54:54.35            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:54.39         SEDTRN\n",
-      "2024-12-16 14:54:54.40            Error count 6720: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
-      "2024-12-16 14:54:54.48         RQUAL\n",
-      "2024-12-16 14:54:55.07         GQUAL\n",
-      "2024-12-16 14:54:55.58      IMPLND I001 DELT(minutes): 60\n",
-      "2024-12-16 14:54:55.59         SNOW\n",
-      "2024-12-16 14:54:55.66         IWATER\n",
-      "2024-12-16 14:54:55.69         SOLIDS\n",
-      "2024-12-16 14:54:55.70         IWTGAS\n",
-      "2024-12-16 14:54:55.72         IQUAL\n",
-      "2024-12-16 14:54:55.75      RCHRES R005 DELT(minutes): 60\n",
-      "2024-12-16 14:54:55.76         HYDR\n",
-      "2024-12-16 14:54:55.82         ADCALC\n",
-      "2024-12-16 14:54:55.82         CONS\n",
-      "2024-12-16 14:54:55.85         HTRCH\n",
-      "2024-12-16 14:54:55.85            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
-      "2024-12-16 14:54:55.89         SEDTRN\n",
-      "2024-12-16 14:54:55.98         RQUAL\n",
-      "2024-12-16 14:54:56.58         GQUAL\n",
-      "2024-12-16 14:54:57.10      GENER G002 DELT(minutes): 60\n",
-      "2024-12-16 14:54:57.11   Done; Run time is about 00:09.6 (mm:ss)\n",
+      "2024-12-17 10:50:28.06   Processing started for file /Users/aaufdenkampe/Documents/Python/respec.HSPsquared/examples/_TutorialData/test10.h5; saveall=True\n",
+      "2024-12-17 10:50:30.10   Simulation Start: 1976-01-01 00:00:00, Stop: 1977-01-01 00:00:00\n",
+      "2024-12-17 10:50:30.10      PERLND P001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:30.13         SNOW\n",
+      "2024-12-17 10:50:30.19         PWATER\n",
+      "2024-12-17 10:50:30.29         PSTEMP\n",
+      "2024-12-17 10:50:30.31         PWTGAS\n",
+      "2024-12-17 10:50:30.37      RCHRES R001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:30.38         HYDR\n",
+      "2024-12-17 10:50:30.44         ADCALC\n",
+      "2024-12-17 10:50:30.45         CONS\n",
+      "2024-12-17 10:50:30.47         HTRCH\n",
+      "2024-12-17 10:50:30.52         SEDTRN\n",
+      "2024-12-17 10:50:30.62         RQUAL\n",
+      "2024-12-17 10:50:31.39         GQUAL\n",
+      "2024-12-17 10:50:32.04      GENER G001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:32.04      RCHRES R002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:32.05         HYDR\n",
+      "2024-12-17 10:50:32.10         ADCALC\n",
+      "2024-12-17 10:50:32.10         CONS\n",
+      "2024-12-17 10:50:32.12         HTRCH\n",
+      "2024-12-17 10:50:32.13            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:32.16         SEDTRN\n",
+      "2024-12-17 10:50:32.17            Error count 3598: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:32.24         RQUAL\n",
+      "2024-12-17 10:50:32.78         GQUAL\n",
+      "2024-12-17 10:50:33.24      RCHRES R003 DELT(minutes): 60\n",
+      "2024-12-17 10:50:33.25         HYDR\n",
+      "2024-12-17 10:50:33.30         ADCALC\n",
+      "2024-12-17 10:50:33.30         CONS\n",
+      "2024-12-17 10:50:33.32         HTRCH\n",
+      "2024-12-17 10:50:33.32            Error count 3: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:33.35         SEDTRN\n",
+      "2024-12-17 10:50:33.36            Error count 513: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:33.43         RQUAL\n",
+      "2024-12-17 10:50:33.93         GQUAL\n",
+      "2024-12-17 10:50:34.31      RCHRES R004 DELT(minutes): 60\n",
+      "2024-12-17 10:50:34.34         HYDR\n",
+      "2024-12-17 10:50:34.39         ADCALC\n",
+      "2024-12-17 10:50:34.39         CONS\n",
+      "2024-12-17 10:50:34.41         HTRCH\n",
+      "2024-12-17 10:50:34.42            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:34.45         SEDTRN\n",
+      "2024-12-17 10:50:34.46            Error count 6720: SEDTRN: Warning -- bed storage of sediment size fraction sand is empty\n",
+      "2024-12-17 10:50:34.54         RQUAL\n",
+      "2024-12-17 10:50:35.10         GQUAL\n",
+      "2024-12-17 10:50:35.58      IMPLND I001 DELT(minutes): 60\n",
+      "2024-12-17 10:50:35.58         SNOW\n",
+      "2024-12-17 10:50:35.64         IWATER\n",
+      "2024-12-17 10:50:35.67         SOLIDS\n",
+      "2024-12-17 10:50:35.68         IWTGAS\n",
+      "2024-12-17 10:50:35.70         IQUAL\n",
+      "2024-12-17 10:50:35.73      RCHRES R005 DELT(minutes): 60\n",
+      "2024-12-17 10:50:35.74         HYDR\n",
+      "2024-12-17 10:50:35.79         ADCALC\n",
+      "2024-12-17 10:50:35.79         CONS\n",
+      "2024-12-17 10:50:35.81         HTRCH\n",
+      "2024-12-17 10:50:35.81            Error count 1: HTRCH: Water temperature is above 66 C (150 F) -- In most cases, this indicates an instability in advection\n",
+      "2024-12-17 10:50:35.85         SEDTRN\n",
+      "2024-12-17 10:50:35.93         RQUAL\n",
+      "2024-12-17 10:50:36.51         GQUAL\n",
+      "2024-12-17 10:50:37.01      GENER G002 DELT(minutes): 60\n",
+      "2024-12-17 10:50:37.01   Done; Run time is about 00:08.9 (mm:ss)\n",
       "\n",
       "\n",
       "                                                       version\n",
       "name                                                         \n",
-      "Python      3.10.16 | packaged by conda-forge | (main, Dec...\n",
+      "Python      3.12.8 | packaged by conda-forge | (main, Dec ...\n",
       "hsp2                                                      n/a\n",
-      "numpy                                                  1.26.4\n",
+      "numpy                                                   2.0.2\n",
       "numba                                                  0.60.0\n",
-      "pandas                                                  2.0.0\n",
+      "pandas                                                  2.2.3\n",
       "jupyterlab                                              4.3.3\n",
       "notebook                                                  n/a\n",
       "os                               macOS-14.7.1-arm64-arm-64bit\n",
       "processor                                                 arm\n",
-      "Date/Time                          2024-12-16T14:54:57.117542\n",
-      "CPU times: user 9.23 s, sys: 491 ms, total: 9.73 s\n",
-      "Wall time: 9.67 s\n"
+      "Date/Time                          2024-12-17T10:50:37.025483\n",
+      "CPU times: user 8.56 s, sys: 408 ms, total: 8.97 s\n",
+      "Wall time: 8.99 s\n"
      ]
     }
    ],
@@ -1407,7 +1689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1416,7 +1698,7 @@
        "[]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1440,7 +1722,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hsp2_py310",
+   "display_name": "hsp2",
    "language": "python",
    "name": "python3"
   },
@@ -1454,7 +1736,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   },
   "toc-autonumbering": true,
   "toc-showmarkdowntxt": false

--- a/src/hsp2/__init__.py
+++ b/src/hsp2/__init__.py
@@ -1,0 +1,23 @@
+"""The Hydrologic Simulation Program - Python (HSP2) watershed model is is a 
+ port of the well-established Hydrological Simulation Program - FORTRAN (HSPF),
+ re-coded with modern scientific Python and data formats.
+
+ Modules:
+    - HSP2 contains the hydrology and water quality code modules converted from 
+    HSPF, along with the main programs to run HSP2.
+    - HSP2tools contains supporting software modules such as the code to convert 
+    legacy WDM and UCI files to HDF5 files for HSP2, and to provide additional 
+    new and legacy capabilities.
+    - HSP2IO is new in v0.10 and contains an abstracted approach to getting data 
+    in and out of HSP2 for flexibility and performance and also to support future 
+    automation and model coupling. 
+"""
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("hsp2")
+except PackageNotFoundError:
+    import os
+    with open(os.path.join(os.path.dirname(__file__),"../..", "VERSION"), encoding="ascii") as version_file:
+        __version__ = version_file.read().strip()

--- a/src/hsp2/hsp2/__init__.py
+++ b/src/hsp2/hsp2/__init__.py
@@ -1,12 +1,9 @@
-"""Copyright (c) 2020 by RESPEC, INC.
-Authors: Robert Heaphy, Ph.D. and Paul Duda
-License: LGPL2
+"""The `hsp2` module contains the hydrology and water quality code modules 
+ converted from HSPF, along with the main programs to run HSP2
 """
-
-from importlib.metadata import version
 
 from hsp2.hsp2.main import main
 from hsp2.hsp2.mainDoE import main as mainDoE
 from hsp2.hsp2.utilities import flowtype, versions
 
-__version__ = version("hsp2")
+from hsp2 import __version__

--- a/src/hsp2/hsp2io/__init__.py
+++ b/src/hsp2/hsp2io/__init__.py
@@ -1,0 +1,6 @@
+"""The `hsp2io` module contains an abstracted approach to getting data in and 
+    out of HSP2 for flexibility and performance and also to support future 
+    automation and model coupling.
+"""
+
+from hsp2 import __version__

--- a/src/hsp2/hsp2tools/__init__.py
+++ b/src/hsp2/hsp2tools/__init__.py
@@ -1,4 +1,7 @@
-from importlib.metadata import version
+"""The `hsp2tools` module contains supporting software modules such as the code
+    to convert legacy WDM and UCI files to HDF5 files for HSP2, and to provide 
+    additional new and legacy capabilities.
+"""
 
 from .clone import clone, removeClone
 from .fetch import fetchtable
@@ -15,4 +18,4 @@ from .readUCI import readUCI
 from .readWDM import readWDM
 from .restart import restart
 
-__version__ = version("hsp2")
+from hsp2 import __version__


### PR DESCRIPTION
This PR:
- Fixes the version attribute import error when in conda develop mode, while also preserving the versioning for packaging. It does so by moving the code from `_version.py` into the main init file. Thanks [@ptomasula](https://github.com/ptomasula) for helping me work through this "cake-and-eat-it-too" approach!
- Adds module-level docstrings.
- Updates environment files to follow conventions (i.e. putting Python version at top; put env managment at the bottom). 
- Changed default environment name to `hsp2` and unconstrained Python to >=3.10. 

In my test of these updates to `environment.yml`, conda installed Python 3.12.8, and everything worked well. 
- NOTE that 3.12 became the default with [Anaconda 2024.06-1 (Jun 26, 2024)](https://docs.anaconda.com/anaconda/release-notes/#anaconda-2024-06-1-jun-26-2024), so all major scientific Python packages support it.
    - Python 3.12 is faster than Python 3.10. In my quick comparison, it was about a 10-15% speedup, but it can be up to 2x faster in some cases (see https://medium.com/@spraneeth4/from-python-3-10-to-3-12-specializing-adaptive-interpreter-delivers-real-world-performance-57b7712dbb97)

cc: @timcera 
