### PR TITLE
Add update_uci mode in CLI and test UCI files

### DIFF
--- a/src/hsp2/hsp2tools/HSP2_CLI.py
+++ b/src/hsp2/hsp2tools/HSP2_CLI.py
@@ -1,11 +1,12 @@
 import cltoolbox
 
-from hsp2.hsp2tools.commands import import_uci, run
+from hsp2.hsp2tools.commands import import_uci, update_uci, run
 
 
 def main():
     cltoolbox.command(run)
     cltoolbox.command(import_uci)
+    cltoolbox.command(update_uci)
     cltoolbox.main()
 
 

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -57,3 +57,30 @@ def import_uci(ucifile, h5file):
             wdmfile = (uci_dir / nline[16:].strip()).resolve()
             if wdmfile.exists():
                 readWDM(wdmfile, h5file)
+
+
+
+
+def update_uci(ucifile, h5file):
+    """Import UCI only into HDF5 file.
+
+    Parameters
+    ----------
+    ucifile: str
+        The UCI file to import into HDF file.
+    h5file: str
+        The destination HDF5 file.
+    """
+    # we send False here to prevent deleting and recreating the UCI
+    print("Updating parameters in h5 file from UCI.", ucifile)
+    print("Note: this will NOT update external data such as WDM, mutsin etc.")
+    print("To update all data, use the command 'hsp2 import_uci ...' ")
+    readUCI(ucifile, h5file, False)
+    with open(ucifile) as fp:
+        uci = []
+        for line in fp.readlines():
+            if "***" in line[:81]:
+                continue
+            if not line[:81].strip():
+                continue
+            uci.append(line[:81].rstrip())

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+https://github.com/HARPgroup/HSPsquared/blob/develop-state-class/src/hsp2/hsp2tools/data/rename.csvfrom pathlib import Path
 
 from hsp2.hsp2.main import main
 from hsp2.hsp2io.hdf import HDF5
@@ -76,11 +76,3 @@ def update_uci(ucifile, h5file):
     print("Note: this will NOT update external data such as WDM, mutsin etc.")
     print("To update all data, use the command 'hsp2 import_uci ...' ")
     readUCI(ucifile, h5file, False)
-    with open(ucifile) as fp:
-        uci = []
-        for line in fp.readlines():
-            if "***" in line[:81]:
-                continue
-            if not line[:81].strip():
-                continue
-            uci.append(line[:81].rstrip())

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -1,4 +1,4 @@
-https://github.com/HARPgroup/HSPsquared/blob/develop-state-class/src/hsp2/hsp2tools/data/rename.csvfrom pathlib import Path
+from pathlib import Path
 
 from hsp2.hsp2.main import main
 from hsp2.hsp2io.hdf import HDF5

--- a/tests/testcbp/HSP2results/PL3_5250_0001eq.uci
+++ b/tests/testcbp/HSP2results/PL3_5250_0001eq.uci
@@ -1,0 +1,228 @@
+RUN
+*** This UCI will load a companion file with JSON in it
+
+GLOBAL
+  PL3_5250_0 riv | P5 | hsp2_2022  | Occoquan
+  START       2001/01/01        END    2001/12/31
+  RUN INTERP OUTPUT LEVEL    1    1
+  RESUME     0 RUN     1                   UNIT SYSTEM     1
+END GLOBAL
+
+FILES
+<FILE>  <UN#>***<----FILE NAME------------------------------------------------->
+WDM1       21   met_A51059.wdm
+WDM2       22   prad_A51059.wdm
+WDM3       23   ps_sep_div_ams_hsp2_2022_PL3_5250_0001.wdm
+WDM4       24   PL3_5250_0001.wdm
+MESSU      25   PL3_5250_0001.ech
+           26   PL3_5250_0001.out
+           31   PL3_5250_0001.tau
+END FILES
+
+OPN SEQUENCE
+    INGRP              INDELT 01:00
+      RCHRES       1
+      PLTGEN       1
+    END INGRP
+END OPN SEQUENCE
+
+RCHRES
+  ACTIVITY
+    # -  # HYFG ADFG CNFG HTFG SDFG GQFG OXFG NUFG PKFG PHFG ***
+    1         1    1    0    0    0    0    0    0    0    0
+  END ACTIVITY
+
+  PRINT-INFO
+    # -  # HYFG ADFG CNFG HTFG SDFG GQFG OXFG NUFG PKFG PHFG PIVL***PY
+    1         5    5    0    0    0    0    0    0    0    0    0   12
+  END PRINT-INFO
+
+  GEN-INFO
+    RCHRES<-------Name------->Nexit   Unit Systems   Printer      ***
+    # -  #                          User t-series  Engl Metr LKFG ***
+    1      PL3_5250_0001          3    1    1    1   26    0    1
+  END GEN-INFO
+
+  HYDR-PARM1
+    RCHRES  Flags for HYDR section                    ***
+    # -  #  VC A1 A2 A3  ODFVFG for each     ODGTFG for each *** FUNCT  for each
+            FG FG FG FG  possible   exit     possible   exit *** possible   exit
+                           1  2  3  4  5       1  2  3  4  5 ***   1  2  3  4  5
+            VC A1 A2 A3   V1 V2 V3 V4 V5      G1 G2 G3 G4 G5 ***  F1 F2 F3 F4 F5
+    1        0  1  1  1    0  0  4  0  0       1  2  0  0  0       0  0  0  0  0
+  END HYDR-PARM1
+
+  HYDR-PARM2
+    RCHRES                                                             ***
+    # -  #    FTABNO       LEN     DELTH     STCOR        KS      DB50 ***
+    1             1.       10.        2.                 0.5
+  END HYDR-PARM2
+
+  HYDR-INIT
+    RCHRES  Initial conditions for HYDR section     ***
+    # -  #       VOL       Initial value of COLIND  ***  Initial value of OUTDGT
+             (ac-ft)       for each  possible exit  ***  for each  possible exit
+                 VOL      CEX1 CEX2 CEX3 CEX4 CEX5  *** DEX1 DEX2 DEX3 DEX4 DEX5
+    1      12175.000
+  END HYDR-INIT
+
+  ADCALC-DATA
+    RCHRES  Data for section ADCALC ***
+    # -  #     CRRAT       VOL      ***
+    1            1.5    12175.
+  END ADCALC-DATA
+
+END RCHRES
+
+FTABLES
+  FTABLE      1
+ ROWS COLS ***
+   20    4
+     DEPTH      AREA    VOLUME     DISCH ***
+      (FT)   (ACRES)   (AC-FT)     (CFS) ***
+         0         0         0         0
+        20       124      1007         0
+        30       240      2781         0
+        40       444      6106         0
+        50       804     12175         0
+        52       909     13886        39
+        54      1024     15819        78
+        56      1155     17999       117
+        57      1226     19227       136
+        58      1296     20456       137
+        60      1413     23180       138
+        62      1524     26140       140
+        63      1586     27745      1922
+        64      1647     29351      5179
+        65      1701     31247      9398
+        66      1755     33143     14393
+        67      1803     34984     20645
+        69      1879     38705     36532
+        70      1908     40585     44603
+        76      2100     54000    103071
+  END FTABLE  1
+END FTABLES
+
+EXT SOURCES
+<-Volume-> <Member> SsysSgap<--Mult-->Tran <-Target vols> <-Grp> <-Member->***
+<Name>   # <Name> # tem strg<-factor->strg <Name>   #   #        <Name> # #***
+*** METEOROLOGY
+WDM1  1000 EVAP     ENGLZERO  1.000   SAME RCHRES   1     EXTNL  POTEV
+WDM1  1001 DEWP     ENGLZERO          SAME RCHRES   1     EXTNL  DEWTMP
+WDM1  1002 WNDH     ENGLZERO          SAME RCHRES   1     EXTNL  WIND
+WDM1  1003 RADH     ENGLZERO          SAME RCHRES   1     EXTNL  SOLRAD
+WDM1  1004 ATMP     ENGLZERO          SAME RCHRES   1     EXTNL  GATMP
+WDM1  1005 CLDC     ENGLZERO          SAME RCHRES   1     EXTNL  CLOUD
+
+*** PRECIPITATION AND ATMOSPHERIC DEPOSITION LOADS
+WDM2  2000 HPRC     ENGLZERO          SAME RCHRES   1     EXTNL  PREC
+WDM2  2001 NO23     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 1 1
+WDM2  2002 NH4A     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 2 1
+WDM2  2003 NO3D     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 1 1
+WDM2  2004 NH4D     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 2 1
+WDM2  2005 ORGN     ENGLZERO          DIV  RCHRES   1     EXTNL  PLADFX 1 1
+WDM2  2006 PO4A     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 3 1
+WDM2  2007 ORGP     ENGLZERO          DIV  RCHRES   1     EXTNL  PLADFX 2 1
+
+*** POINT SOURCE
+WDM3  3000 FLOW     ENGLZERO          DIV  RCHRES   1     INFLOW IVOL
+WDM3  3001 HEAT     ENGLZERO          DIV  RCHRES   1     INFLOW IHEAT
+WDM3  3002 NH3X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  2
+WDM3  3003 NO3X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  1
+WDM3  3004 ORNX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   3
+WDM3  3005 PO4X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  4
+WDM3  3006 ORPX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   4
+WDM3  3021 BODX     ENGLZERO          DIV  RCHRES   1     INFLOW OXIF   2
+WDM3  3022 TSSX     ENGLZERO  0.0005  DIV  RCHRES   1     INFLOW ISED   3
+WDM3  3023 DOXX     ENGLZERO          DIV  RCHRES   1     INFLOW OXIF   1
+WDM3  3024 TOCX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   5
+
+*** DIVERSIONS
+WDM3  3007 DIVR     ENGLZERO          SAME RCHRES   1     EXTNL  OUTDGT 1
+WDM3  3008 DIVA     ENGLZERO          SAME RCHRES   1     EXTNL  OUTDGT 2
+
+*** SEPTIC
+WDM3  3010 SNO3     ENGLZERO  1.0000  DIV  RCHRES   1     INFLOW NUIF1  1
+
+*** AEOLIAN SEDIMENT
+WDM3  3061 SFAS     ENGLZERO 7.027e-06DIV  RCHRES   1     INFLOW ISED   2
+WDM3  3062 SFAC     ENGLZERO 7.027e-06DIV  RCHRES   1     INFLOW ISED   3
+
+*** UPSTREAM and EOS INPUT ***
+WDM4    11 WATR     ENGLZERO          SAME RCHRES   1     INFLOW IVOL
+WDM4    12 HEAT     ENGLZERO          SAME RCHRES   1     INFLOW IHEAT
+WDM4    13 DOXY     ENGLZERO          SAME RCHRES   1     INFLOW OXIF   1
+WDM4    21 SAND     ENGLZERO          SAME RCHRES   1     INFLOW ISED   1
+WDM4    22 SILT     ENGLZERO          SAME RCHRES   1     INFLOW ISED   2
+WDM4    23 CLAY     ENGLZERO          SAME RCHRES   1     INFLOW ISED   3
+WDM4    31 NO3D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  1
+WDM4    32 NH3D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  2
+WDM4    33 NH3A     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  1 1
+WDM4    34 NH3I     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  2 1
+WDM4    35 NH3C     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  3 1
+WDM4    36 RORN     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   3
+WDM4    41 PO4D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  4
+WDM4    42 PO4A     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  1 2
+WDM4    43 PO4I     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  2 2
+WDM4    44 PO4C     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  3 2
+WDM4    45 RORP     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   4
+WDM4    51 BODA     ENGLZERO          SAME RCHRES   1     INFLOW OXIF   2
+WDM4    52 TORC     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   5
+WDM4    53 PHYT     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   1
+END EXT SOURCES
+
+EXT TARGETS
+<-Volume-> <-Grp> <-Member-><--Mult-->Tran <-Volume-> <Member> Tsys Tgap Amd ***
+<Name>   #        <Name> # #<-factor->strg <Name>   # <Name> #  tem strg strg***
+RCHRES   1 OFLOW  OVOL   3            SAME WDM4   111 WATR     ENGL      REPL
+RCHRES   1 OFLOW  OHEAT  3            SAME WDM4   112 HEAT     ENGL      REPL
+RCHRES   1 OFLOW  OXCF2  3 1          SAME WDM4   113 DOXY     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 1          SAME WDM4   121 SAND     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 2          SAME WDM4   122 SILT     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 3          SAME WDM4   123 CLAY     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 1          SAME WDM4   131 NO3D     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 2          SAME WDM4   132 NH3D     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 1          SAME WDM4   133 NH3A     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 2          SAME WDM4   134 NH3I     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 3          SAME WDM4   135 NH3C     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 3          SAME WDM4   136 RORN     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 4          SAME WDM4   141 PO4D     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 1          SAME WDM4   142 PO4A     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 2          SAME WDM4   143 PO4I     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 3          SAME WDM4   144 PO4C     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 4          SAME WDM4   145 RORP     ENGL      REPL
+RCHRES   1 OFLOW  OXCF2  3 2          SAME WDM4   151 BODA     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 5          SAME WDM4   152 TORC     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 1          SAME WDM4   153 PHYT     ENGL      REPL
+END EXT TARGETS
+
+NETWORK
+<-Volume-> <-Grp> <-Member-><--Mult-->Tran <-Target vols> <-Grp> <-Member-> ***
+<Name>   #        <Name> # #<-factor->strg <Name>   #   #        <Name> # # ***
+RCHRES   1 HYDR   TAU                 AVER PLTGEN   1     INPUT  MEAN   1
+END NETWORK
+
+PLTGEN
+  PLOTINFO
+    # -  # FILE  NPT  NMN LABL  PYR PIVL ***
+    1        31         1        12   24
+  END PLOTINFO
+
+  GEN-LABELS
+    # -  #<----------------Title----------------->   ***
+    1         PL3_5250_0001 daily_shear_stress_lbsft2
+  END GEN-LABELS
+
+  SCALING
+    #thru#      YMIN      YMAX     IVLIN     THRESH ***
+    1   99        0.   100000.       20.
+  END SCALING
+
+  CURV-DATA
+              <-Curve label--> Line Intg  Col Tran ***
+    # -  #                     type  eqv code code ***
+    1         daily_shear_stre         1    1 AVER
+  END CURV-DATA
+END PLTGEN
+
+END RUN

--- a/tests/testcbp/HSP2results/PL3_5250_0001eqlong.uci
+++ b/tests/testcbp/HSP2results/PL3_5250_0001eqlong.uci
@@ -1,0 +1,228 @@
+RUN
+*** This UCI will load a companion file with JSON in it
+
+GLOBAL
+  PL3_5250_0 riv | P5 | hsp2_2022  | Occoquan
+  START       1984/01/01        END    2019/12/31
+  RUN INTERP OUTPUT LEVEL    1    1
+  RESUME     0 RUN     1                   UNIT SYSTEM     1
+END GLOBAL
+
+FILES
+<FILE>  <UN#>***<----FILE NAME------------------------------------------------->
+WDM1       21   met_A51059.wdm
+WDM2       22   prad_A51059.wdm
+WDM3       23   ps_sep_div_ams_hsp2_2022_PL3_5250_0001.wdm
+WDM4       24   PL3_5250_0001.wdm
+MESSU      25   PL3_5250_0001.ech
+           26   PL3_5250_0001.out
+           31   PL3_5250_0001.tau
+END FILES
+
+OPN SEQUENCE
+    INGRP              INDELT 01:00
+      RCHRES       1
+      PLTGEN       1
+    END INGRP
+END OPN SEQUENCE
+
+RCHRES
+  ACTIVITY
+    # -  # HYFG ADFG CNFG HTFG SDFG GQFG OXFG NUFG PKFG PHFG ***
+    1         1    1    0    0    0    0    0    0    0    0
+  END ACTIVITY
+
+  PRINT-INFO
+    # -  # HYFG ADFG CNFG HTFG SDFG GQFG OXFG NUFG PKFG PHFG PIVL***PY
+    1         5    5    0    0    0    0    0    0    0    0    0   12
+  END PRINT-INFO
+
+  GEN-INFO
+    RCHRES<-------Name------->Nexit   Unit Systems   Printer      ***
+    # -  #                          User t-series  Engl Metr LKFG ***
+    1      PL3_5250_0001          3    1    1    1   26    0    1
+  END GEN-INFO
+
+  HYDR-PARM1
+    RCHRES  Flags for HYDR section                    ***
+    # -  #  VC A1 A2 A3  ODFVFG for each     ODGTFG for each *** FUNCT  for each
+            FG FG FG FG  possible   exit     possible   exit *** possible   exit
+                           1  2  3  4  5       1  2  3  4  5 ***   1  2  3  4  5
+            VC A1 A2 A3   V1 V2 V3 V4 V5      G1 G2 G3 G4 G5 ***  F1 F2 F3 F4 F5
+    1        0  1  1  1    0  0  4  0  0       1  2  0  0  0       0  0  0  0  0
+  END HYDR-PARM1
+
+  HYDR-PARM2
+    RCHRES                                                             ***
+    # -  #    FTABNO       LEN     DELTH     STCOR        KS      DB50 ***
+    1             1.       10.        2.                 0.5
+  END HYDR-PARM2
+
+  HYDR-INIT
+    RCHRES  Initial conditions for HYDR section     ***
+    # -  #       VOL       Initial value of COLIND  ***  Initial value of OUTDGT
+             (ac-ft)       for each  possible exit  ***  for each  possible exit
+                 VOL      CEX1 CEX2 CEX3 CEX4 CEX5  *** DEX1 DEX2 DEX3 DEX4 DEX5
+    1      12175.000
+  END HYDR-INIT
+
+  ADCALC-DATA
+    RCHRES  Data for section ADCALC ***
+    # -  #     CRRAT       VOL      ***
+    1            1.5    12175.
+  END ADCALC-DATA
+
+END RCHRES
+
+FTABLES
+  FTABLE      1
+ ROWS COLS ***
+   20    4
+     DEPTH      AREA    VOLUME     DISCH ***
+      (FT)   (ACRES)   (AC-FT)     (CFS) ***
+         0         0         0         0
+        20       124      1007         0
+        30       240      2781         0
+        40       444      6106         0
+        50       804     12175         0
+        52       909     13886        39
+        54      1024     15819        78
+        56      1155     17999       117
+        57      1226     19227       136
+        58      1296     20456       137
+        60      1413     23180       138
+        62      1524     26140       140
+        63      1586     27745      1922
+        64      1647     29351      5179
+        65      1701     31247      9398
+        66      1755     33143     14393
+        67      1803     34984     20645
+        69      1879     38705     36532
+        70      1908     40585     44603
+        76      2100     54000    103071
+  END FTABLE  1
+END FTABLES
+
+EXT SOURCES
+<-Volume-> <Member> SsysSgap<--Mult-->Tran <-Target vols> <-Grp> <-Member->***
+<Name>   # <Name> # tem strg<-factor->strg <Name>   #   #        <Name> # #***
+*** METEOROLOGY
+WDM1  1000 EVAP     ENGLZERO  1.000   SAME RCHRES   1     EXTNL  POTEV
+WDM1  1001 DEWP     ENGLZERO          SAME RCHRES   1     EXTNL  DEWTMP
+WDM1  1002 WNDH     ENGLZERO          SAME RCHRES   1     EXTNL  WIND
+WDM1  1003 RADH     ENGLZERO          SAME RCHRES   1     EXTNL  SOLRAD
+WDM1  1004 ATMP     ENGLZERO          SAME RCHRES   1     EXTNL  GATMP
+WDM1  1005 CLDC     ENGLZERO          SAME RCHRES   1     EXTNL  CLOUD
+
+*** PRECIPITATION AND ATMOSPHERIC DEPOSITION LOADS
+WDM2  2000 HPRC     ENGLZERO          SAME RCHRES   1     EXTNL  PREC
+WDM2  2001 NO23     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 1 1
+WDM2  2002 NH4A     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 2 1
+WDM2  2003 NO3D     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 1 1
+WDM2  2004 NH4D     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 2 1
+WDM2  2005 ORGN     ENGLZERO          DIV  RCHRES   1     EXTNL  PLADFX 1 1
+WDM2  2006 PO4A     ENGLZERO          DIV  RCHRES   1     EXTNL  NUADFX 3 1
+WDM2  2007 ORGP     ENGLZERO          DIV  RCHRES   1     EXTNL  PLADFX 2 1
+
+*** POINT SOURCE
+WDM3  3000 FLOW     ENGLZERO          DIV  RCHRES   1     INFLOW IVOL
+WDM3  3001 HEAT     ENGLZERO          DIV  RCHRES   1     INFLOW IHEAT
+WDM3  3002 NH3X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  2
+WDM3  3003 NO3X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  1
+WDM3  3004 ORNX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   3
+WDM3  3005 PO4X     ENGLZERO          DIV  RCHRES   1     INFLOW NUIF1  4
+WDM3  3006 ORPX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   4
+WDM3  3021 BODX     ENGLZERO          DIV  RCHRES   1     INFLOW OXIF   2
+WDM3  3022 TSSX     ENGLZERO  0.0005  DIV  RCHRES   1     INFLOW ISED   3
+WDM3  3023 DOXX     ENGLZERO          DIV  RCHRES   1     INFLOW OXIF   1
+WDM3  3024 TOCX     ENGLZERO          DIV  RCHRES   1     INFLOW PKIF   5
+
+*** DIVERSIONS
+WDM3  3007 DIVR     ENGLZERO          SAME RCHRES   1     EXTNL  OUTDGT 1
+WDM3  3008 DIVA     ENGLZERO          SAME RCHRES   1     EXTNL  OUTDGT 2
+
+*** SEPTIC
+WDM3  3010 SNO3     ENGLZERO  1.0000  DIV  RCHRES   1     INFLOW NUIF1  1
+
+*** AEOLIAN SEDIMENT
+WDM3  3061 SFAS     ENGLZERO 7.027e-06DIV  RCHRES   1     INFLOW ISED   2
+WDM3  3062 SFAC     ENGLZERO 7.027e-06DIV  RCHRES   1     INFLOW ISED   3
+
+*** UPSTREAM and EOS INPUT ***
+WDM4    11 WATR     ENGLZERO          SAME RCHRES   1     INFLOW IVOL
+WDM4    12 HEAT     ENGLZERO          SAME RCHRES   1     INFLOW IHEAT
+WDM4    13 DOXY     ENGLZERO          SAME RCHRES   1     INFLOW OXIF   1
+WDM4    21 SAND     ENGLZERO          SAME RCHRES   1     INFLOW ISED   1
+WDM4    22 SILT     ENGLZERO          SAME RCHRES   1     INFLOW ISED   2
+WDM4    23 CLAY     ENGLZERO          SAME RCHRES   1     INFLOW ISED   3
+WDM4    31 NO3D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  1
+WDM4    32 NH3D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  2
+WDM4    33 NH3A     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  1 1
+WDM4    34 NH3I     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  2 1
+WDM4    35 NH3C     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  3 1
+WDM4    36 RORN     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   3
+WDM4    41 PO4D     ENGLZERO          SAME RCHRES   1     INFLOW NUIF1  4
+WDM4    42 PO4A     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  1 2
+WDM4    43 PO4I     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  2 2
+WDM4    44 PO4C     ENGLZERO          SAME RCHRES   1     INFLOW NUIF2  3 2
+WDM4    45 RORP     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   4
+WDM4    51 BODA     ENGLZERO          SAME RCHRES   1     INFLOW OXIF   2
+WDM4    52 TORC     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   5
+WDM4    53 PHYT     ENGLZERO          SAME RCHRES   1     INFLOW PKIF   1
+END EXT SOURCES
+
+EXT TARGETS
+<-Volume-> <-Grp> <-Member-><--Mult-->Tran <-Volume-> <Member> Tsys Tgap Amd ***
+<Name>   #        <Name> # #<-factor->strg <Name>   # <Name> #  tem strg strg***
+RCHRES   1 OFLOW  OVOL   3            SAME WDM4   111 WATR     ENGL      REPL
+RCHRES   1 OFLOW  OHEAT  3            SAME WDM4   112 HEAT     ENGL      REPL
+RCHRES   1 OFLOW  OXCF2  3 1          SAME WDM4   113 DOXY     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 1          SAME WDM4   121 SAND     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 2          SAME WDM4   122 SILT     ENGL      REPL
+RCHRES   1 OFLOW  OSED   3 3          SAME WDM4   123 CLAY     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 1          SAME WDM4   131 NO3D     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 2          SAME WDM4   132 NH3D     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 1          SAME WDM4   133 NH3A     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 2          SAME WDM4   134 NH3I     ENGL      REPL
+RCHRES   1 OFLOW  OSNH4  3 3          SAME WDM4   135 NH3C     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 3          SAME WDM4   136 RORN     ENGL      REPL
+RCHRES   1 OFLOW  NUCF9  3 4          SAME WDM4   141 PO4D     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 1          SAME WDM4   142 PO4A     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 2          SAME WDM4   143 PO4I     ENGL      REPL
+RCHRES   1 OFLOW  OSPO4  3 3          SAME WDM4   144 PO4C     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 4          SAME WDM4   145 RORP     ENGL      REPL
+RCHRES   1 OFLOW  OXCF2  3 2          SAME WDM4   151 BODA     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 5          SAME WDM4   152 TORC     ENGL      REPL
+RCHRES   1 OFLOW  PKCF2  3 1          SAME WDM4   153 PHYT     ENGL      REPL
+END EXT TARGETS
+
+NETWORK
+<-Volume-> <-Grp> <-Member-><--Mult-->Tran <-Target vols> <-Grp> <-Member-> ***
+<Name>   #        <Name> # #<-factor->strg <Name>   #   #        <Name> # # ***
+RCHRES   1 HYDR   TAU                 AVER PLTGEN   1     INPUT  MEAN   1
+END NETWORK
+
+PLTGEN
+  PLOTINFO
+    # -  # FILE  NPT  NMN LABL  PYR PIVL ***
+    1        31         1        12   24
+  END PLOTINFO
+
+  GEN-LABELS
+    # -  #<----------------Title----------------->   ***
+    1         PL3_5250_0001 daily_shear_stress_lbsft2
+  END GEN-LABELS
+
+  SCALING
+    #thru#      YMIN      YMAX     IVLIN     THRESH ***
+    1   99        0.   100000.       20.
+  END SCALING
+
+  CURV-DATA
+              <-Curve label--> Line Intg  Col Tran ***
+    # -  #                     type  eqv code code ***
+    1         daily_shear_stre         1    1 AVER
+  END CURV-DATA
+END PLTGEN
+
+END RUN


### PR DESCRIPTION
This is a prototype to allow an update of settings ONLY from a UCI into an hdf5 that has already been created with `hsp2 import_uci ...`.
- Copies parameters over, but **omits timeseries data like WDM, mutsin ...**
- This results in a huge time savings when testing, and I can only imagine that if I were developing a model that was UCI based, I would be very grateful for this feaure.
- I consider this ready to merge as it DOES work initially, but caveats follow.
- This works well the first time, but subsequent attempts fail when trying to run due to duplicate column names that occur due to renaming in the function `readUCI()`
- See this issue for details on the problems with this function after the 2nd update attempt: https://github.com/respec/HSPsquared/issues/201