### PR TITLE
Develop testdir

### DIFF
--- a/examples/state_specl_ops/demo_specl_initialize.py
+++ b/examples/state_specl_ops/demo_specl_initialize.py
@@ -7,25 +7,25 @@ from hsp2.hsp2.main import *
 from hsp2.hsp2.om import *
 from hsp2.hsp2.state import *
 from hsp2.hsp2io.hdf import HDF5
-from hsp2.hsp2io.io import IOManager
+from hsp2.hsp2io.io import io_manager
 hdf5_instance = HDF5("./tests/test10specl/HSP2results/test10specl.demo.h5")
 
 
-iomanager = IOManager(hdf5_instance)
-uci_obj = iomanager.read_uci()
+io_manager = io_manager(hdf5_instance)
+uci_obj = io_manager.read_uci()
 siminfo = uci_obj.siminfo
 opseq = uci_obj.opseq
 state = init_state_dicts()
-state_siminfo_hsp2(uci_obj, siminfo, iomanager, state)
+state_siminfo_hsp2(uci_obj, siminfo, io_manager, state)
 
 # Add support for dynamic functions to operate on STATE
-state_load_dynamics_hsp2(state, iomanager, siminfo)
+state_load_dynamics_hsp2(state, io_manager, siminfo)
 state_init_hsp2(state, opseq, activities)
 state["specactions"] = uci_obj.specactions  # stash the specaction dict in state
 om_init_state(state)  # set up operational model specific state entries
-specl_load_state(state, iomanager, siminfo)  # traditional special actions
-state_load_dynamics_om(state, iomanager, siminfo) 
-state_om_model_run_prep(state, iomanager, siminfo)
+specl_load_state(state, io_manager, siminfo)  # traditional special actions
+state_load_dynamics_om(state, io_manager, siminfo) 
+state_om_model_run_prep(state, io_manager, siminfo)
 state_context_hsp2(state, "RCHRES", "R005", "SEDTRN")
 
 domain, state_paths, state_ix, dict_ix, ts_ix, op_tokens = state["domain"], state["state_paths"], state["state_ix"], state["dict_ix"], state["ts_ix"], state["op_tokens"]

--- a/src/hsp2/hsp2/main.py
+++ b/src/hsp2/hsp2/main.py
@@ -704,23 +704,23 @@ def get_flows(
                         t = data_frame[smemn].astype(float64).to_numpy()[0:steps]
 
                     if MFname in ts and AFname in ts:
-                        t *= ts[MFname][:steps] * ts[AFname][0:steps]
+                        t = t * ts[MFname][:steps] * ts[AFname][0:steps]
                         msg(4, f"MFACTOR modified by timeseries {MFname}")
                         msg(4, f"AFACTR modified by timeseries {AFname}")
                     elif MFname in ts:
-                        t *= afactr * ts[MFname][0:steps]
+                        t = t * afactr * ts[MFname][0:steps]
                         msg(4, f"MFACTOR modified by timeseries {MFname}")
                     elif AFname in ts:
-                        t *= mfactor * ts[AFname][0:steps]
+                        t = t * mfactor * ts[AFname][0:steps]
                         msg(4, f"AFACTR modified by timeseries {AFname}")
                     else:
-                        t *= factor
+                        t = t * factor
 
                     # if poht to iheat, imprecision in hspf conversion factor requires a slight adjustment
                     if (smemn == "POHT" or smemn == "SOHT") and tmemn == "IHEAT":
-                        t *= 0.998553
+                        t = t * 0.998553
                     if (smemn == "PODOXM" or smemn == "SODOXM") and tmemn == "OXIF1":
-                        t *= 1.000565
+                        t = t * 1.000565
 
                     # ??? ISSUE: can fetched data be at different frequency - don't know how to transform.
                     if tmemn in ts:

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -14,7 +14,7 @@ import pandas as pd
 from numba import types
 from numba.typed import Dict
 from numpy import float64, full, tile, zeros
-from pandas import Series, date_range
+from pandas import Series, date_range, Timedelta
 from pandas.tseries.offsets import Minute
 
 from hsp2.hsp2io.protocols import Category, SupportsReadTS, SupportsWriteTS
@@ -213,8 +213,9 @@ def transform(ts, name, how, siminfo):
     NOTE: these routines work for both regular and sparse timeseries input
     """
 
-    tsfreq = ts.index.freq
-    freq = Minute(siminfo["delt"])
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
     stop = siminfo["stop"]
 
     # append duplicate of last point to force processing last full interval
@@ -226,7 +227,7 @@ def transform(ts, name, how, siminfo):
     elif tsfreq is None:  # Sparse time base, frequency not defined
         ts = ts.reindex(siminfo["tbase"]).ffill().bfill()
     elif how == "SAME":
-        ts = ts.resample(freq).ffill()  # tsfreq >= freq assumed, or bad user choice
+        ts = ts.resample(fmins).ffill()  # tsfreq >= freq assumed, or bad user choice
     elif not how:
         if name in flowtype:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
@@ -236,24 +237,24 @@ def transform(ts, name, how, siminfo):
                     ratio = 1.0 / 8766.0
                 else:
                     ratio = freq / tsfreq
-                ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+                ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
             else:
-                ts = ts.resample(freq).sum()
+                ts = ts.resample(fmins).sum()
         else:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
-                ts = ts.resample(freq).ffill()
+                ts = ts.resample(fmins).ffiio_managerll()
             else:
-                ts = ts.resample(freq).mean()
+                ts = ts.resample(fmins).mean()
     elif how == "MEAN":
-        ts = ts.resample(freq).mean()
+        ts = ts.resample(fmins).mean()
     elif how == "SUM":
-        ts = ts.resample(freq).sum()
+        ts = ts.resample(fmins).sum()
     elif how == "MAX":
-        ts = ts.resample(freq).max()
+        ts = ts.resample(fmins).max()
     elif how == "MIN":
-        ts = ts.resample(freq).min()
+        ts = ts.resample(fmins).min()
     elif how == "LAST":
-        ts = ts.resample(freq).ffill()
+        ts = ts.resample(fmins).ffill()
     elif how == "DIV":
         if "Y" in str(tsfreq) or "M" in str(tsfreq):
             mult = 1
@@ -268,13 +269,13 @@ def transform(ts, name, how, siminfo):
                 ratio = 1.0 / (8766.0 * mult)
             else:
                 ratio = freq / tsfreq
-            ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+            ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
         else:
-            ts = (ts * (freq / ts.index.freq)).resample(freq).ffill()
+            ts = (ts * (freq / tsfreq)).resample(fmins).ffill()
     elif how == "ZEROFILL":
-        ts = ts.resample(freq).fillna(0.0)
+        ts = ts.resample(fmins).fillna(0.0)
     elif how == "INTERPOLATE":
-        ts = ts.resample(freq).interpolate()
+        ts = ts.resample(fmins).interpolate()
     else:
         print(f"UNKNOWN method in TRANS, {how}")
         return zeros(1)
@@ -287,7 +288,8 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
     """create hours flags, flag on the hour or lapse table over full simulation"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     dr = date_range(
         start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq=Minute(60)
@@ -297,16 +299,17 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
         hours[0] = 1
 
     ts = Series(hours[0 : len(dr)], dr)
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
     if lapselike:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().ffill()
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).mean()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().ffill()
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).mean()
     else:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().fillna(0.0)
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).max()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().fillna(0.0)
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).max()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -321,16 +324,18 @@ def monthval(siminfo, monthly):
     """returns value at start of month for all times within the month"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").ffill()
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).asfreq().ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).asfreq().ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -339,16 +344,19 @@ def dayval(siminfo, monthly):
     interpolation to day, but constant within day"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").interpolate("time")
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -24,6 +24,7 @@ def run(h5file, saveall=True, compress=True):
     hdf5_instance = HDF5(h5file)
     io_manager = IOManager(hdf5_instance)
     main(io_manager, saveall=saveall, jupyterlab=compress)
+    hdf5_instance.close()
 
 
 def import_uci(ucifile, h5file):
@@ -57,3 +58,22 @@ def import_uci(ucifile, h5file):
             wdmfile = (uci_dir / nline[16:].strip()).resolve()
             if wdmfile.exists():
                 readWDM(wdmfile, h5file)
+
+
+
+
+def update_uci(ucifile, h5file):
+    """Import UCI only into HDF5 file.
+
+    Parameters
+    ----------
+    ucifile: str
+        The UCI file to import into HDF file.
+    h5file: str
+        The destination HDF5 file.
+    """
+    # we send False here to prevent deleting and recreating the UCI
+    print("Updating parameters in h5 file from UCI.", ucifile)
+    print("Note: this will NOT update external data such as WDM, mutsin etc.")
+    print("To update all data, use the command 'hsp2 import_uci ...' ")
+    readUCI(ucifile, h5file, False)

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -23,6 +23,7 @@ class RegressTest:
         tcodes: List[str] = ["2"],
         ids: List[str] = [],
         threads: int = os.cpu_count() - 1,
+        tests_root_dir = None
     ) -> None:
         self.compare_case = compare_case
         self.operations = operations
@@ -30,23 +31,25 @@ class RegressTest:
         self.tcodes = tcodes
         self.ids = ids
         self.threads = threads
-
+        if tests_root_dir is None:
+            current_directory = os.path.dirname(
+                os.path.abspath(inspect.getframeinfo(inspect.currentframe()).filename)
+            )
+            source_root_path = os.path.split(os.path.split(current_directory)[0])[0]
+            self.tests_root_dir = os.path.join(source_root_path, "tests")
+        else:
+            self.tests_root_dir = tests_root_dir
         self._init_files()
 
     def _init_files(self):
-        current_directory = os.path.dirname(
-            os.path.abspath(inspect.getframeinfo(inspect.currentframe()).filename)
-        )
-        source_root_path = os.path.split(os.path.split(current_directory)[0])[0]
-        tests_root_dir = os.path.join(source_root_path, "tests")
         self.html_file = os.path.join(
-            tests_root_dir, f"HSPF_HSP2_{self.compare_case}.html"
+            self.tests_root_dir, f"HSPF_HSP2_{self.compare_case}.html"
         )
 
-        test_dirs = os.listdir(tests_root_dir)
+        test_dirs = os.listdir(self.tests_root_dir)
         for test_dir in test_dirs:
             if test_dir == self.compare_case:
-                test_root = os.path.join(tests_root_dir, test_dir)
+                test_root = os.path.join(self.tests_root_dir, test_dir)
 
         self._get_hdf5_data(test_root)
         self._get_hbn_data(test_root)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -41,9 +41,10 @@ class RegressTest(RegressTestBase):
         self.hsp2_data = HDF5(str(self.temp_h5file))
 
     def _init_files(self):
+        print("Checking tests_root_dir has tests in the name")
         assert self.tests_root_dir.name == "tests"
-
         test_root = self.tests_root_dir / self.compare_case
+        print("Checking case tests_dir exists:", test_root)
         assert test_root.exists()
 
         self._get_hbn_data(str(test_root))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,6 +8,23 @@ from .convert.regression_base import RegressTest as RegressTestBase
 
 
 class RegressTest(RegressTestBase):
+    def __init__(
+        self,
+        compare_case: str,
+        operations: List[str] = [],
+        activities: List[str] = [],
+        tcodes: List[str] = ["2"],
+        ids: List[str] = [],
+        threads: int = os.cpu_count() - 1,
+        tests_root_dir = None
+    ) -> None:
+        if tests_root_dir is None:
+            tests_root_dir = Path(__file__).resolve().parent
+        super(RegressTest, self).__init__(
+            compare_case, operations, activities, 
+            tcodes, ids, threads, tests_root_dir
+        )
+
     def _get_hsp2_data(self, test_root) -> None:
         test_root_hspf = Path(test_root) / "HSPFresults"
         hspf_uci = test_root_hspf.resolve() / f"{self.compare_case}.uci"
@@ -24,10 +41,9 @@ class RegressTest(RegressTestBase):
         self.hsp2_data = HDF5(str(self.temp_h5file))
 
     def _init_files(self):
-        test_dir = Path(__file__).resolve().parent
-        assert test_dir.name == "tests"
+        assert self.tests_root_dir.name == "tests"
 
-        test_root = test_dir / self.compare_case
+        test_root = self.tests_root_dir / self.compare_case
         assert test_root.exists()
 
         self._get_hbn_data(str(test_root))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -10,14 +10,9 @@ from .convert.regression_base import RegressTest as RegressTestBase
 
 
 class RegressTest(RegressTestBase):
-    def __init__(
-        self,
-        compare_case: str,
-        operations: List[str] = [],
-        activities: List[str] = [],
-        tcodes: List[str] = ["2"],
-        ids: List[str] = [],
-        threads: int = os.cpu_count() - 1,
+    def __init__(self,  compare_case: str, operations: List[str] = [],
+        activities: List[str] = [], tcodes: List[str] = ["2"],
+        ids: List[str] = [], threads: int = os.cpu_count() - 1,
         tests_root_dir = None
     ) -> None:
         if tests_root_dir is None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 import pytest
 from hsp2.hsp2tools.commands import import_uci, run

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from hsp2.hsp2tools.commands import import_uci, run
 from hsp2.hsp2tools.HDF5 import HDF5
+from typing import Dict, List, Tuple, Union
 
 from .convert.regression_base import RegressTest as RegressTestBase
 


### PR DESCRIPTION
@austinorr This is an attempt at a minor modification of the testing class for the purpose of enabling more flexible test directory handling, basically:
- Allowing the test classes to be run at the command prompt, whereas, the existing version of `RegressTest` breaks if run from a command prompt because the variable `__file__` does not exist in that context.
- Updates the base class `RegressTestBase` to accept an argument `tests_root_dir`
- Adds a subclass of `__init__` on `RegressTest` to accept the `tests_root_dir` argument
- Moves the guessing the `test_root_dir` from the `__file__` into this `__init__` method instead of the `_init_files()` method.
   - Primarily I did this because it would fit better IMO to do that guesswork in `__init__`
   - Second motivation was that it made the relationship between those two classes a bit more consistent, since they currently use slightly different variable names in `_init_files()` to represent the same thing, which caused me some confusion when looking through the code.

I am not super attached to this change, as the process of writing the code allowed me to see a little further into the testing harness, and in the process I learned enough to perhaps *not need* the ability to call it from an interactive shell, but I like the options personally, so I submit it for your consideration.