### PR TITLE
make a small doc change to test tests

### DIFF
--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -1,18 +1,19 @@
 """General routines for state variable storage.
 
 Provides a facility for sharing information among different
-Model domains and entities.
+model domains and entities.
 """
 
+import importlib.util
+import os
+import sys
+
 import numpy as np
-from pandas import date_range
-from pandas.tseries.offsets import Minute
+from numba import njit, types  # import the types
 from numba.typed import Dict
 from numpy import zeros
-from numba import njit, types  # import the types
-import os
-import importlib.util
-import sys
+from pandas import date_range
+from pandas.tseries.offsets import Minute
 
 
 def init_state_dicts():

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -1,4 +1,8 @@
-"""General routines for SPECL"""
+"""General routines for state variable storage.
+
+Provides a facility for sharing information among different
+Model domains and entities.
+"""
 
 import numpy as np
 from pandas import date_range


### PR DESCRIPTION
This is OK to merge, but only corrects a small piece of documentation. Main purpose is triggering test bot.  
- and as can be seen, with only an addition of a single comment line, 5 tests fail, identical to the test that failed in this PR #204 
- No python 3.9 or 3.10 tests fail.
- Consistent with #204 and also #202 -- all tests fail with 
   - `FAILED tests/ipwater/test_ipwater.py::test_pwater - TypeError: '>' not supported between instances of 'pandas._libs.tslibs.offsets.Day' and 'pandas._libs.tslibs.offsets.Minute'
   - `...`