### PR TITLE
Testy

### DIFF
--- a/examples/state_specl_ops/demo_specl_initialize.py
+++ b/examples/state_specl_ops/demo_specl_initialize.py
@@ -7,25 +7,25 @@ from hsp2.hsp2.main import *
 from hsp2.hsp2.om import *
 from hsp2.hsp2.state import *
 from hsp2.hsp2io.hdf import HDF5
-from hsp2.hsp2io.io import IOManager
+from hsp2.hsp2io.io import io_manager
 hdf5_instance = HDF5("./tests/test10specl/HSP2results/test10specl.demo.h5")
 
 
-iomanager = IOManager(hdf5_instance)
-uci_obj = iomanager.read_uci()
+io_manager = io_manager(hdf5_instance)
+uci_obj = io_manager.read_uci()
 siminfo = uci_obj.siminfo
 opseq = uci_obj.opseq
 state = init_state_dicts()
-state_siminfo_hsp2(uci_obj, siminfo, iomanager, state)
+state_siminfo_hsp2(uci_obj, siminfo, io_manager, state)
 
 # Add support for dynamic functions to operate on STATE
-state_load_dynamics_hsp2(state, iomanager, siminfo)
+state_load_dynamics_hsp2(state, io_manager, siminfo)
 state_init_hsp2(state, opseq, activities)
 state["specactions"] = uci_obj.specactions  # stash the specaction dict in state
 om_init_state(state)  # set up operational model specific state entries
-specl_load_state(state, iomanager, siminfo)  # traditional special actions
-state_load_dynamics_om(state, iomanager, siminfo) 
-state_om_model_run_prep(state, iomanager, siminfo)
+specl_load_state(state, io_manager, siminfo)  # traditional special actions
+state_load_dynamics_om(state, io_manager, siminfo) 
+state_om_model_run_prep(state, io_manager, siminfo)
 state_context_hsp2(state, "RCHRES", "R005", "SEDTRN")
 
 domain, state_paths, state_ix, dict_ix, ts_ix, op_tokens = state["domain"], state["state_paths"], state["state_ix"], state["dict_ix"], state["ts_ix"], state["op_tokens"]

--- a/src/hsp2/hsp2/main.py
+++ b/src/hsp2/hsp2/main.py
@@ -704,23 +704,23 @@ def get_flows(
                         t = data_frame[smemn].astype(float64).to_numpy()[0:steps]
 
                     if MFname in ts and AFname in ts:
-                        t *= ts[MFname][:steps] * ts[AFname][0:steps]
+                        t = t * ts[MFname][:steps] * ts[AFname][0:steps]
                         msg(4, f"MFACTOR modified by timeseries {MFname}")
                         msg(4, f"AFACTR modified by timeseries {AFname}")
                     elif MFname in ts:
-                        t *= afactr * ts[MFname][0:steps]
+                        t = t * afactr * ts[MFname][0:steps]
                         msg(4, f"MFACTOR modified by timeseries {MFname}")
                     elif AFname in ts:
-                        t *= mfactor * ts[AFname][0:steps]
+                        t = t * mfactor * ts[AFname][0:steps]
                         msg(4, f"AFACTR modified by timeseries {AFname}")
                     else:
-                        t *= factor
+                        t = t * factor
 
                     # if poht to iheat, imprecision in hspf conversion factor requires a slight adjustment
                     if (smemn == "POHT" or smemn == "SOHT") and tmemn == "IHEAT":
-                        t *= 0.998553
+                        t = t * 0.998553
                     if (smemn == "PODOXM" or smemn == "SODOXM") and tmemn == "OXIF1":
-                        t *= 1.000565
+                        t = t * 1.000565
 
                     # ??? ISSUE: can fetched data be at different frequency - don't know how to transform.
                     if tmemn in ts:

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -14,7 +14,7 @@ import pandas as pd
 from numba import types
 from numba.typed import Dict
 from numpy import float64, full, tile, zeros
-from pandas import Series, date_range
+from pandas import Series, date_range, Timedelta
 from pandas.tseries.offsets import Minute
 
 from hsp2.hsp2io.protocols import Category, SupportsReadTS, SupportsWriteTS
@@ -213,8 +213,9 @@ def transform(ts, name, how, siminfo):
     NOTE: these routines work for both regular and sparse timeseries input
     """
 
-    tsfreq = ts.index.freq
-    freq = Minute(siminfo["delt"])
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
     stop = siminfo["stop"]
 
     # append duplicate of last point to force processing last full interval
@@ -226,7 +227,7 @@ def transform(ts, name, how, siminfo):
     elif tsfreq is None:  # Sparse time base, frequency not defined
         ts = ts.reindex(siminfo["tbase"]).ffill().bfill()
     elif how == "SAME":
-        ts = ts.resample(freq).ffill()  # tsfreq >= freq assumed, or bad user choice
+        ts = ts.resample(fmins).ffill()  # tsfreq >= freq assumed, or bad user choice
     elif not how:
         if name in flowtype:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
@@ -236,24 +237,24 @@ def transform(ts, name, how, siminfo):
                     ratio = 1.0 / 8766.0
                 else:
                     ratio = freq / tsfreq
-                ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+                ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
             else:
-                ts = ts.resample(freq).sum()
+                ts = ts.resample(fmins).sum()
         else:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
-                ts = ts.resample(freq).ffill()
+                ts = ts.resample(fmins).ffiio_managerll()
             else:
-                ts = ts.resample(freq).mean()
+                ts = ts.resample(fmins).mean()
     elif how == "MEAN":
-        ts = ts.resample(freq).mean()
+        ts = ts.resample(fmins).mean()
     elif how == "SUM":
-        ts = ts.resample(freq).sum()
+        ts = ts.resample(fmins).sum()
     elif how == "MAX":
-        ts = ts.resample(freq).max()
+        ts = ts.resample(fmins).max()
     elif how == "MIN":
-        ts = ts.resample(freq).min()
+        ts = ts.resample(fmins).min()
     elif how == "LAST":
-        ts = ts.resample(freq).ffill()
+        ts = ts.resample(fmins).ffill()
     elif how == "DIV":
         if "Y" in str(tsfreq) or "M" in str(tsfreq):
             mult = 1
@@ -268,13 +269,13 @@ def transform(ts, name, how, siminfo):
                 ratio = 1.0 / (8766.0 * mult)
             else:
                 ratio = freq / tsfreq
-            ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+            ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
         else:
-            ts = (ts * (freq / ts.index.freq)).resample(freq).ffill()
+            ts = (ts * (freq / tsfreq)).resample(fmins).ffill()
     elif how == "ZEROFILL":
-        ts = ts.resample(freq).fillna(0.0)
+        ts = ts.resample(fmins).fillna(0.0)
     elif how == "INTERPOLATE":
-        ts = ts.resample(freq).interpolate()
+        ts = ts.resample(fmins).interpolate()
     else:
         print(f"UNKNOWN method in TRANS, {how}")
         return zeros(1)
@@ -287,7 +288,8 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
     """create hours flags, flag on the hour or lapse table over full simulation"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     dr = date_range(
         start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq=Minute(60)
@@ -297,16 +299,17 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
         hours[0] = 1
 
     ts = Series(hours[0 : len(dr)], dr)
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
     if lapselike:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().ffill()
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).mean()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().ffill()
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).mean()
     else:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().fillna(0.0)
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).max()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().fillna(0.0)
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).max()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -321,16 +324,18 @@ def monthval(siminfo, monthly):
     """returns value at start of month for all times within the month"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").ffill()
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).asfreq().ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).asfreq().ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -339,16 +344,19 @@ def dayval(siminfo, monthly):
     interpolation to day, but constant within day"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").interpolate("time")
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 

--- a/src/hsp2/hsp2io/hdf.py
+++ b/src/hsp2/hsp2io/hdf.py
@@ -13,8 +13,11 @@ class HDF5:
         self._store = pd.HDFStore(file_path)
         None
 
-    def __del__(self):
+    def close(self):
         self._store.close()
+
+    def __del__(self):
+        self.close()
 
     def __enter__(self):
         return self

--- a/src/hsp2/hsp2tools/HBNOutput.py
+++ b/src/hsp2/hsp2tools/HBNOutput.py
@@ -169,7 +169,22 @@ class HBNOutput:
                         return data_frame[cons_key]
 
         return None
-
+    
+    def _read_table(
+            self, t_opn: str, t_opn_id: int, t_activity: str, time_unit: str
+    ) -> pd.DataFrame:
+        # returns a single pandas dataframe of the entire table
+        # time_unit matches self.tcodes = {1: 'Minutely', 2: 'Hourly', 3: 'Daily', 4: 'Monthly', 5: 'Yearly'}
+        table_path = '_'.join([t_opn, t_activity, t_opn_id, self._get_tcode_key(time_unit)])
+        data_frame = self.data_frames[self.summaryindx.index(table_path)]
+        return data_frame
+    
+    def _get_tcode_key(self, time_unit: str, default: int) -> int:
+        for tcode_key in self.tcodes.keys():
+            if self.tcodes[tcode_key].lower() == time_unit:
+                return tcode_key
+        return default
+    
     # PRT - I think we'll deprecate this method
     @staticmethod
     def save_time_series_to_file(file_name: str, time_series: pd.Series) -> None:

--- a/src/hsp2/hsp2tools/HBNOutput.py
+++ b/src/hsp2/hsp2tools/HBNOutput.py
@@ -147,6 +147,9 @@ class HBNOutput:
         3.     t_cons: target constituent name
         4. t_activity: HYDR, IQUAL, etc
         5.  time_unit: yearly, monthly, full (default is 'full' simulation duration)
+        # todo: the "full" doesnt have a match in the table, and is hard coded below 
+                as target_code = 2, which is hourly, but some HSP simulations will
+                be Minutes, therefore this is misleading. 
         """
         target_tcode = 2
         for tcode_key in self.tcodes.keys():
@@ -183,7 +186,7 @@ class HBNOutput:
         for tcode_key in self.tcodes.keys():
             if self.tcodes[tcode_key].lower() == time_unit:
                 return tcode_key
-        return default
+        raise Exception(f"time_unit {time_unit} Not Found. Valid values are", self.tcodes)
     
     # PRT - I think we'll deprecate this method
     @staticmethod

--- a/src/hsp2/hsp2tools/HBNOutput.py
+++ b/src/hsp2/hsp2tools/HBNOutput.py
@@ -178,13 +178,13 @@ class HBNOutput:
     ) -> pd.DataFrame:
         # returns a single pandas dataframe of the entire table
         # time_unit matches self.tcodes = {1: 'Minutely', 2: 'Hourly', 3: 'Daily', 4: 'Monthly', 5: 'Yearly'}
-        table_path = '_'.join([t_opn, t_activity, t_opn_id, self._get_tcode_key(time_unit)])
+        table_path = '_'.join([t_opn, t_activity, t_opn_id, str(self._get_tcode_key(time_unit))])
         data_frame = self.data_frames[self.summaryindx.index(table_path)]
         return data_frame
     
     def _get_tcode_key(self, time_unit: str) -> int:
         for tcode_key in self.tcodes.keys():
-            if self.tcodes[tcode_key].lower() == time_unit:
+            if self.tcodes[tcode_key].lower() == time_unit.lower():
                 return tcode_key
         raise Exception(f"time_unit {time_unit} Not Found. Valid values are", self.tcodes)
     

--- a/src/hsp2/hsp2tools/HBNOutput.py
+++ b/src/hsp2/hsp2tools/HBNOutput.py
@@ -179,7 +179,7 @@ class HBNOutput:
         data_frame = self.data_frames[self.summaryindx.index(table_path)]
         return data_frame
     
-    def _get_tcode_key(self, time_unit: str, default: int) -> int:
+    def _get_tcode_key(self, time_unit: str) -> int:
         for tcode_key in self.tcodes.keys():
             if self.tcodes[tcode_key].lower() == time_unit:
                 return tcode_key

--- a/src/hsp2/hsp2tools/HBNOutput.py
+++ b/src/hsp2/hsp2tools/HBNOutput.py
@@ -178,7 +178,7 @@ class HBNOutput:
     ) -> pd.DataFrame:
         # returns a single pandas dataframe of the entire table
         # time_unit matches self.tcodes = {1: 'Minutely', 2: 'Hourly', 3: 'Daily', 4: 'Monthly', 5: 'Yearly'}
-        table_path = '_'.join([t_opn, t_activity, t_opn_id, str(self._get_tcode_key(time_unit))])
+        table_path = '_'.join([t_opn, t_activity, str(t_opn_id), str(self._get_tcode_key(time_unit))])
         data_frame = self.data_frames[self.summaryindx.index(table_path)]
         return data_frame
     

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -24,6 +24,7 @@ def run(h5file, saveall=True, compress=True):
     hdf5_instance = HDF5(h5file)
     io_manager = IOManager(hdf5_instance)
     main(io_manager, saveall=saveall, jupyterlab=compress)
+    hdf5_instance.close()
 
 
 def import_uci(ucifile, h5file):
@@ -57,3 +58,22 @@ def import_uci(ucifile, h5file):
             wdmfile = (uci_dir / nline[16:].strip()).resolve()
             if wdmfile.exists():
                 readWDM(wdmfile, h5file)
+
+
+
+
+def update_uci(ucifile, h5file):
+    """Import UCI only into HDF5 file.
+
+    Parameters
+    ----------
+    ucifile: str
+        The UCI file to import into HDF file.
+    h5file: str
+        The destination HDF5 file.
+    """
+    # we send False here to prevent deleting and recreating the UCI
+    print("Updating parameters in h5 file from UCI.", ucifile)
+    print("Note: this will NOT update external data such as WDM, mutsin etc.")
+    print("To update all data, use the command 'hsp2 import_uci ...' ")
+    readUCI(ucifile, h5file, False)

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -9,76 +9,29 @@ from hsp2.hsp2tools.commands import import_uci, run
 from hsp2.hsp2tools.HDF5 import HDF5
 from typing import Dict, List, Tuple, Union
 
-from convert.regression_base import RegressTest as RegressTestBase
+from convert.regression_base import RegressTest
 
 
-class RegressTest(RegressTestBase):
-    def __init__(self,  compare_case: str, operations: List[str] = [],
-        activities: List[str] = [], tcodes: List[str] = ["2"],
-        ids: List[str] = [], threads: int = os.cpu_count() - 1,
-        tests_root_dir = None
-    ) -> None:
-        if tests_root_dir is None:
-            tests_root_dir = Path(__file__).resolve().parent
-        super(RegressTest, self).__init__(
-            compare_case, operations, activities, 
-            tcodes, ids, threads, tests_root_dir
-        )
-    
-    def _get_hsp2_data(self, test_root) -> None:
-        test_root_hspf = Path(test_root) / "HSPFresults"
-        hspf_uci = test_root_hspf.resolve() / f"{self.compare_case}.uci"
-        assert hspf_uci.exists()
-        
-        temp_h5file = test_root_hspf / f"{self.compare_case}.h5"
-        if temp_h5file.exists():
-            temp_h5file.unlink()
-        
-        self.temp_h5file = temp_h5file
-        
-        import_uci(str(hspf_uci), str(self.temp_h5file))
-        run(self.temp_h5file, saveall=True, compress=False)
-        self.hsp2_data = HDF5(str(self.temp_h5file))
-    
-    def _init_files(self):
-        print("Checking tests_root_dir has tests in the name")
-        assert self.tests_root_dir.name == "tests"
-        test_root = self.tests_root_dir / self.compare_case
-        print("Checking case tests_dir exists:", test_root)
-        assert test_root.exists()
-        
-        self._get_hbn_data(str(test_root))
-        self._get_hsp2_data(str(test_root))
+case = "test10"
 
+test = RegressTest(case, threads=1)
+test.run_hsp2() # todo: this should go away and be called outside the test class
+results = test.run_test()
+test.temp_h5file.unlink()
 
-@pytest.mark.parametrize(
-    "case",
-    [
-        # "test05",
-        # "test09",
-        "test10",
-        "test10specl",
-        # "test10b",
-    ],
-)
-def test_case(case):
-    test = RegressTest(case, threads=1)
-    results = test.run_test()
-    test.temp_h5file.unlink()
+found = False
+mismatches = []
+for key, results in results.items():
+    no_data_hsp2, no_data_hspf, match, diff = results
+    if any([no_data_hsp2, no_data_hspf]):
+        continue
+    if not match:
+        mismatches.append((case, key, results))
+    found = True
+assert found
 
-    found = False
-    mismatches = []
-    for key, results in results.items():
-        no_data_hsp2, no_data_hspf, match, diff = results
-        if any([no_data_hsp2, no_data_hspf]):
-            continue
-        if not match:
-            mismatches.append((case, key, results))
-        found = True
-    assert found
-
-    if mismatches:
-        for case, key, results in mismatches:
-            _, _, _, diff = results
-            print(case, key, f"{diff:0.00%}")
-        raise ValueError("results don't match hspf output")
+if mismatches:
+    for case, key, results in mismatches:
+        _, _, _, diff = results
+        print(case, key, f"{diff:0.00%}")
+    raise ValueError("results don't match hspf output")

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -4,15 +4,16 @@
 from pathlib import Path
 import os
 import pandas as pd
+import numpy as np
 from hsp2.hsp2tools.commands import import_uci, run
 from hsp2.hsp2tools.HDF5 import HDF5 # note: has handy function get_time_series() 
 from hsp2.hsp2tools.HBNOutput import HBNOutput # Also has function get_time_series()
 
-from convert.regression_base import RegressTest
+from tests.convert.regression_base import RegressTest
 
 
-case = "test10"
-#case = "testcbp"
+#case = "test10"
+case = "testcbp"
 tdir = "/opt/model/HSPsquared/tests"
 #import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
 #run(temp_specl_h5file, saveall=True, compress=False)
@@ -21,9 +22,12 @@ tdir = "/opt/model/HSPsquared/tests"
 
 ############# HSPF NO SPECL
 hspf_hbn_path = os.path.join(tdir, case, "HSPFresults", case + 'R.hbn')
+hsp2_hdf_path = os.path.join(tdir, case, "HSP2results", case + '.h5')
 hspf_hbn = HBNOutput(hspf_hbn_path)
 hspf_hbn.read_data()
-rcres_hydr_hsp2 = hspf_hbn.get_time_series('RCHRES', 1, 'OVOL', 'HYDR', 'full')
+rchres_hydr_hspf_ovol = hspf_hbn.get_time_series('RCHRES', 1, 'OVOL', 'HYDR', 'full')
+rchres_hydr_hspf = hspf_hbn._read_table('RCHRES', '001', 'HYDR', 'Hourly')
+np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
 
 
 test = RegressTest(case, threads=1, tests_root_dir = tdir)
@@ -34,7 +38,7 @@ test.temp_h5file.unlink()
 rchres_hydr_test = test.hsp2_data.data[('RCHRES', '005', 'HYDR')]
 test_dir = os.path.join(test.tests_root_dir, test.compare_case)
 # test_dir=tdir + '/' + case 
-dstore_hsp2 = pd.HDFStore(str(test_dir) + '/HSP2results/' + case + '.h5', mode='r')
+dstore_hsp2 = pd.HDFStore(str(tdir) + '/HSP2results/' + case + '.h5', mode='r')
 rchres_hydr_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/RCHRES_R001/HYDR')
 perlnd_pwater_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/PERLND_P001/PWATER')
 dstore_hsp2.close() # tidy up

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -3,21 +3,44 @@
 # todo: make this convert path passable by argument 
 from pathlib import Path
 import os
-
-import pytest
+import pandas as pd
 from hsp2.hsp2tools.commands import import_uci, run
-from hsp2.hsp2tools.HDF5 import HDF5
-from typing import Dict, List, Tuple, Union
+from hsp2.hsp2tools.HDF5 import HDF5 # note: has handy function get_time_series() 
+from hsp2.hsp2tools.HBNOutput import HBNOutput # Also has function get_time_series()
 
 from convert.regression_base import RegressTest
 
 
 case = "test10"
+#case = "testcbp"
+tdir = "/opt/model/HSPsquared/tests"
+#import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
+#run(temp_specl_h5file, saveall=True, compress=False)
 
-test = RegressTest(case, threads=1)
-test.run_hsp2() # todo: this should go away and be called outside the test class
+## Manual Data outside of RegressTest
+
+############# HSPF NO SPECL
+hspf_hbn_path = os.path.join(tdir, case, "HSPFresults", case + 'R.hbn')
+hspf_hbn = HBNOutput(hspf_hbn_path)
+hspf_hbn.read_data()
+rcres_hydr_hsp2 = hspf_hbn.get_time_series('RCHRES', 1, 'OVOL', 'HYDR', 'full')
+
+
+test = RegressTest(case, threads=1, tests_root_dir = tdir)
 results = test.run_test()
 test.temp_h5file.unlink()
+
+# test object hydr
+rchres_hydr_test = test.hsp2_data.data[('RCHRES', '005', 'HYDR')]
+test_dir = os.path.join(test.tests_root_dir, test.compare_case)
+# test_dir=tdir + '/' + case 
+dstore_hsp2 = pd.HDFStore(str(test_dir) + '/HSP2results/' + case + '.h5', mode='r')
+rchres_hydr_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/RCHRES_R001/HYDR')
+perlnd_pwater_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/PERLND_P001/PWATER')
+dstore_hsp2.close() # tidy up
+np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
+np.quantile(perlnd_pwater_hsp2['SURO'], [0,0.25,0.5,0.75,1.0])
+
 
 found = False
 mismatches = []

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -12,38 +12,42 @@ from hsp2.hsp2tools.HBNOutput import HBNOutput # Also has function get_time_seri
 from tests.convert.regression_base import RegressTest
 
 
-#case = "test10"
-case = "testcbp"
+case = "test10"
+#case = "testcbp"
 tdir = "/opt/model/HSPsquared/tests"
 #import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
 #run(temp_specl_h5file, saveall=True, compress=False)
 
 ## Manual Data outside of RegressTest
 
-############# HSPF NO SPECL
+############# HSPF RCHRES 1 HYDR (manual)
 hspf_hbn_path = os.path.join(tdir, case, "HSPFresults", case + 'R.hbn')
-hsp2_hdf_path = os.path.join(tdir, case, "HSP2results", case + '.h5')
 hspf_hbn = HBNOutput(hspf_hbn_path)
 hspf_hbn.read_data()
 rchres_hydr_hspf_ovol = hspf_hbn.get_time_series('RCHRES', 1, 'OVOL', 'HYDR', 'full')
 rchres_hydr_hspf = hspf_hbn._read_table('RCHRES', '001', 'HYDR', 'Hourly')
-np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
 
-
-test = RegressTest(case, threads=1, tests_root_dir = tdir)
-results = test.run_test()
-test.temp_h5file.unlink()
-
-# test object hydr
-rchres_hydr_test = test.hsp2_data.data[('RCHRES', '005', 'HYDR')]
-test_dir = os.path.join(test.tests_root_dir, test.compare_case)
-# test_dir=tdir + '/' + case 
-dstore_hsp2 = pd.HDFStore(str(tdir) + '/HSP2results/' + case + '.h5', mode='r')
+############# HSP2 RCHRES 1 HYDR (manual)
+hsp2_hdf_path = os.path.join(tdir, case, "HSP2results", case + '.h5')
+dstore_hsp2 = pd.HDFStore(hsp2_hdf_path, mode='r')
 rchres_hydr_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/RCHRES_R001/HYDR')
 perlnd_pwater_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/PERLND_P001/PWATER')
 dstore_hsp2.close() # tidy up
-np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
+
+############# RegressTest data loader
+test = RegressTest(case, threads=1, tests_root_dir = tdir)
+#results = test.run_test()
+
+# test object hydr
+rchres_hydr_hsp2_test = test.hsp2_data.data[('RCHRES', '001', 'HYDR')]
+test_dir = os.path.join(test.tests_root_dir, test.compare_case)
+
 np.quantile(perlnd_pwater_hsp2['SURO'], [0,0.25,0.5,0.75,1.0])
+
+# Compare the hydr
+np.quantile(rchres_hydr_hspf['ROVOL'], [0,0.25,0.5,0.75,1.0])
+np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
+np.quantile(rchres_hydr_hsp2_test['ROVOL'], [0,0.25,0.5,0.75,1.0])
 
 
 found = False

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -45,7 +45,8 @@ rchres_hydr_hspf_base_mo
 
 # Compare ANY arbitrary timeseries, not just the ones coded into the RegressTest object
 # 3rd argument is tolerance to use
-test.compare_time_series(rchres_hydr_hsp2_base_table['RO'], rchres_hydr_hsp2_test_table['RO'], 10.0)
+tol = 10.0
+test.compare_time_series(rchres_hydr_hsp2_base_table['RO'], rchres_hydr_hsp2_test_table['RO'], tol)
 # Example:  (True, 8.7855425)
 
 # Compare inflows and outflows

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -1,0 +1,84 @@
+# Note: This code must be run from the tests dir due to importing
+# the `convert` directory where the regression_base file lives
+# todo: make this convert path passable by argument 
+from pathlib import Path
+import os
+
+import pytest
+from hsp2.hsp2tools.commands import import_uci, run
+from hsp2.hsp2tools.HDF5 import HDF5
+from typing import Dict, List, Tuple, Union
+
+from convert.regression_base import RegressTest as RegressTestBase
+
+
+class RegressTest(RegressTestBase):
+    def __init__(self,  compare_case: str, operations: List[str] = [],
+        activities: List[str] = [], tcodes: List[str] = ["2"],
+        ids: List[str] = [], threads: int = os.cpu_count() - 1,
+        tests_root_dir = None
+    ) -> None:
+        if tests_root_dir is None:
+            tests_root_dir = Path(__file__).resolve().parent
+        super(RegressTest, self).__init__(
+            compare_case, operations, activities, 
+            tcodes, ids, threads, tests_root_dir
+        )
+    
+    def _get_hsp2_data(self, test_root) -> None:
+        test_root_hspf = Path(test_root) / "HSPFresults"
+        hspf_uci = test_root_hspf.resolve() / f"{self.compare_case}.uci"
+        assert hspf_uci.exists()
+        
+        temp_h5file = test_root_hspf / f"{self.compare_case}.h5"
+        if temp_h5file.exists():
+            temp_h5file.unlink()
+        
+        self.temp_h5file = temp_h5file
+        
+        import_uci(str(hspf_uci), str(self.temp_h5file))
+        run(self.temp_h5file, saveall=True, compress=False)
+        self.hsp2_data = HDF5(str(self.temp_h5file))
+    
+    def _init_files(self):
+        print("Checking tests_root_dir has tests in the name")
+        assert self.tests_root_dir.name == "tests"
+        test_root = self.tests_root_dir / self.compare_case
+        print("Checking case tests_dir exists:", test_root)
+        assert test_root.exists()
+        
+        self._get_hbn_data(str(test_root))
+        self._get_hsp2_data(str(test_root))
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # "test05",
+        # "test09",
+        "test10",
+        "test10specl",
+        # "test10b",
+    ],
+)
+def test_case(case):
+    test = RegressTest(case, threads=1)
+    results = test.run_test()
+    test.temp_h5file.unlink()
+
+    found = False
+    mismatches = []
+    for key, results in results.items():
+        no_data_hsp2, no_data_hspf, match, diff = results
+        if any([no_data_hsp2, no_data_hspf]):
+            continue
+        if not match:
+            mismatches.append((case, key, results))
+        found = True
+    assert found
+
+    if mismatches:
+        for case, key, results in mismatches:
+            _, _, _, diff = results
+            print(case, key, f"{diff:0.00%}")
+        raise ValueError("results don't match hspf output")

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -1,55 +1,69 @@
 # Note: This code must be run from the tests dir due to importing
 # the `convert` directory where the regression_base file lives
 # todo: make this convert path passable by argument 
-from pathlib import Path
-import os
-import pandas as pd
 import numpy as np
-from hsp2.hsp2tools.commands import import_uci, run
-from hsp2.hsp2tools.HDF5 import HDF5 # note: has handy function get_time_series() 
-from hsp2.hsp2tools.HBNOutput import HBNOutput # Also has function get_time_series()
-
 from tests.convert.regression_base import RegressTest
 
 
-case = "test10"
+case = "test10specl"
+base_case = "test10"
 #case = "testcbp"
 tdir = "/opt/model/HSPsquared/tests"
 #import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
 #run(temp_specl_h5file, saveall=True, compress=False)
 
-## Manual Data outside of RegressTest
-
-############# HSPF RCHRES 1 HYDR (manual)
-hspf_hbn_path = os.path.join(tdir, case, "HSPFresults", case + 'R.hbn')
-hspf_hbn = HBNOutput(hspf_hbn_path)
-hspf_hbn.read_data()
-rchres_hydr_hspf_ovol = hspf_hbn.get_time_series('RCHRES', 1, 'OVOL', 'HYDR', 'full')
-rchres_hydr_hspf = hspf_hbn._read_table('RCHRES', '001', 'HYDR', 'Hourly')
-
-############# HSP2 RCHRES 1 HYDR (manual)
-hsp2_hdf_path = os.path.join(tdir, case, "HSP2results", case + '.h5')
-dstore_hsp2 = pd.HDFStore(hsp2_hdf_path, mode='r')
-rchres_hydr_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/RCHRES_R001/HYDR')
-perlnd_pwater_hsp2 = pd.read_hdf(dstore_hsp2, '/RESULTS/PERLND_P001/PWATER')
-dstore_hsp2.close() # tidy up
-
 ############# RegressTest data loader
+## TEST CASE
 test = RegressTest(case, threads=1, tests_root_dir = tdir)
-#results = test.run_test()
-
 # test object hydr
-rchres_hydr_hsp2_test = test.hsp2_data.data[('RCHRES', '001', 'HYDR')]
-test_dir = os.path.join(test.tests_root_dir, test.compare_case)
+rchres_hydr_hsp2_test_table = test.hsp2_data._read_table('RCHRES', '001', 'HYDR')
+perlnd_pwat_hsp2_test_table = test.hsp2_data._read_table('PERLND', '001', 'PWATER')
+rchres_hydr_hsp2_test = test.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
+rchres_hydr_hspf_test = test.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2)) #Note: the order of arguments is wonky in Regressbase
+rchres_hydr_hsp2_test_mo = rchres_hydr_hsp2_test.resample('MS').mean()
+rchres_hydr_hspf_test_mo = rchres_hydr_hspf_test.resample('MS').mean()
+## BASE CASE
+base = RegressTest(base_case, threads=1, tests_root_dir = tdir)
+# base object hydr
+rchres_hydr_hsp2_base_table = base.hsp2_data._read_table('RCHRES', '001', 'HYDR')
+perlnd_pwat_hsp2_base_table = base.hsp2_data._read_table('PERLND', '001', 'PWATER')
+rchres_hydr_hsp2_base = base.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
+rchres_hydr_hspf_base = base.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2))  #Note: the order of arguments is wonky in Regressbase
+rchres_hydr_hsp2_base_mo = rchres_hydr_hsp2_base.resample('MS').mean()
+rchres_hydr_hspf_base_mo = rchres_hydr_hspf_base.resample('MS').mean()
 
-np.quantile(perlnd_pwater_hsp2['SURO'], [0,0.25,0.5,0.75,1.0])
+# Show quantiles
+np.quantile(rchres_hydr_hsp2_test, [0,0.25,0.5,0.75,1.0])
+np.quantile(rchres_hydr_hspf_test, [0,0.25,0.5,0.75,1.0])
+np.quantile(rchres_hydr_hsp2_base, [0,0.25,0.5,0.75,1.0])
+np.quantile(rchres_hydr_hspf_base, [0,0.25,0.5,0.75,1.0])
+# Monthly mean value comparisons
+rchres_hydr_hsp2_test_mo
+rchres_hydr_hspf_test_mo
+rchres_hydr_hsp2_base_mo
+rchres_hydr_hspf_base_mo
 
-# Compare the hydr
-np.quantile(rchres_hydr_hspf['ROVOL'], [0,0.25,0.5,0.75,1.0])
-np.quantile(rchres_hydr_hsp2['ROVOL'], [0,0.25,0.5,0.75,1.0])
-np.quantile(rchres_hydr_hsp2_test['ROVOL'], [0,0.25,0.5,0.75,1.0])
+# Compare ANY arbitrary timeseries, not just the ones coded into the RegressTest object
+# 3rd argument is tolerance to use
+test.compare_time_series(rchres_hydr_hsp2_base_table['RO'], rchres_hydr_hsp2_test_table['RO'], 10.0)
+# Example:  (True, 8.7855425)
 
+# Compare inflows and outflows
+np.mean(perlnd_pwat_hsp2_test_table['PERO']) * 6000 * 0.0833
+np.mean(rchres_hydr_hsp2_test_table['IVOL'])
+np.mean(rchres_hydr_hsp2_test_table['ROVOL'])
+np.mean(perlnd_pwat_hsp2_base_table['PERO']) * 6000 * 0.0833
+np.mean(rchres_hydr_hsp2_base_table['IVOL'])
+np.mean(rchres_hydr_hsp2_base_table['ROVOL'])
 
+# now do a comparison
+# HYDR diff should be almost nonexistent
+test.check_con(params = ('RCHRES', 'HYDR', '001', 'ROVOL', 2))
+# this is very large for PWTGAS
+test.check_con(params = ('PERLND', 'PWTGAS', '001', 'POHT', '2'))
+
+# Now run the full test
+results = test.run_test()
 found = False
 mismatches = []
 for key, results in results.items():

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -57,7 +57,7 @@ class RegressTest:
     def _get_hbn_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSPFresults")
         self.hspf_data_collection = {}
-        print("Loading hbs files from hspf data path", sub_dir)
+        print("Loading hbn files from hspf data path", sub_dir)
         for file in os.listdir(sub_dir):
             if file.lower().endswith(".hbn"):
                 hspf_data = HBNOutput(os.path.join(test_dir, sub_dir, file))

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -75,6 +75,7 @@ class RegressTest:
 
     def _get_hdf5_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSP2results")
+        print("hsp2 data path", sub_dir)
         for file in os.listdir(sub_dir):
             if file.lower().endswith(".h5") or file.lower().endswith(".hdf"):
                 self.hsp2_data = HDF5(os.path.join(sub_dir, file))

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -57,6 +57,7 @@ class RegressTest:
     def _get_hbn_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSPFresults")
         self.hspf_data_collection = {}
+        print("Loading hbs files from hspf data path", sub_dir)
         for file in os.listdir(sub_dir):
             if file.lower().endswith(".hbn"):
                 hspf_data = HBNOutput(os.path.join(test_dir, sub_dir, file))
@@ -75,7 +76,7 @@ class RegressTest:
 
     def _get_hdf5_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSP2results")
-        print("hsp2 data path", sub_dir)
+        print("Loading h5 files from hsp2 data path", sub_dir)
         for file in os.listdir(sub_dir):
             if file.lower().endswith(".h5") or file.lower().endswith(".hdf"):
                 self.hsp2_data = HDF5(os.path.join(sub_dir, file))

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -23,6 +23,7 @@ class RegressTest:
         tcodes: List[str] = ["2"],
         ids: List[str] = [],
         threads: int = os.cpu_count() - 1,
+        tests_root_dir = None
     ) -> None:
         self.compare_case = compare_case
         self.operations = operations
@@ -30,23 +31,25 @@ class RegressTest:
         self.tcodes = tcodes
         self.ids = ids
         self.threads = threads
-
+        if tests_root_dir is None:
+            current_directory = os.path.dirname(
+                os.path.abspath(inspect.getframeinfo(inspect.currentframe()).filename)
+            )
+            source_root_path = os.path.split(os.path.split(current_directory)[0])[0]
+            self.tests_root_dir = os.path.join(source_root_path, "tests")
+        else:
+            self.tests_root_dir = tests_root_dir
         self._init_files()
 
     def _init_files(self):
-        current_directory = os.path.dirname(
-            os.path.abspath(inspect.getframeinfo(inspect.currentframe()).filename)
-        )
-        source_root_path = os.path.split(os.path.split(current_directory)[0])[0]
-        tests_root_dir = os.path.join(source_root_path, "tests")
         self.html_file = os.path.join(
-            tests_root_dir, f"HSPF_HSP2_{self.compare_case}.html"
+            self.tests_root_dir, f"HSPF_HSP2_{self.compare_case}.html"
         )
 
-        test_dirs = os.listdir(tests_root_dir)
+        test_dirs = os.listdir(self.tests_root_dir)
         for test_dir in test_dirs:
             if test_dir == self.compare_case:
-                test_root = os.path.join(tests_root_dir, test_dir)
+                test_root = os.path.join(self.tests_root_dir, test_dir)
 
         self._get_hdf5_data(test_root)
         self._get_hbn_data(test_root)

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -75,7 +75,7 @@ class RegressTest:
 
     def _get_hdf5_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSP2results")
-        for file in os.listdir(sub_dir):
+        for file in os.listdir(self.hsp2_dir):
             if file.lower().endswith(".h5") or file.lower().endswith(".hdf"):
                 self.hsp2_data = HDF5(os.path.join(sub_dir, file))
                 break

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -75,7 +75,7 @@ class RegressTest:
 
     def _get_hdf5_data(self, test_dir: str) -> None:
         sub_dir = os.path.join(test_dir, "HSP2results")
-        for file in os.listdir(self.hsp2_dir):
+        for file in os.listdir(sub_dir):
             if file.lower().endswith(".h5") or file.lower().endswith(".hdf"):
                 self.hsp2_data = HDF5(os.path.join(sub_dir, file))
                 break

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -41,9 +41,10 @@ class RegressTest(RegressTestBase):
         self.hsp2_data = HDF5(str(self.temp_h5file))
 
     def _init_files(self):
+        print("Checking tests_root_dir has tests in the name")
         assert self.tests_root_dir.name == "tests"
-
         test_root = self.tests_root_dir / self.compare_case
+        print("Checking case tests_dir exists:", test_root)
         assert test_root.exists()
 
         self._get_hbn_data(str(test_root))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,6 +8,23 @@ from .convert.regression_base import RegressTest as RegressTestBase
 
 
 class RegressTest(RegressTestBase):
+    def __init__(
+        self,
+        compare_case: str,
+        operations: List[str] = [],
+        activities: List[str] = [],
+        tcodes: List[str] = ["2"],
+        ids: List[str] = [],
+        threads: int = os.cpu_count() - 1,
+        tests_root_dir = None
+    ) -> None:
+        if tests_root_dir is None:
+            tests_root_dir = Path(__file__).resolve().parent
+        super(RegressTest, self).__init__(
+            compare_case, operations, activities, 
+            tcodes, ids, threads, tests_root_dir
+        )
+
     def _get_hsp2_data(self, test_root) -> None:
         test_root_hspf = Path(test_root) / "HSPFresults"
         hspf_uci = test_root_hspf.resolve() / f"{self.compare_case}.uci"
@@ -24,10 +41,9 @@ class RegressTest(RegressTestBase):
         self.hsp2_data = HDF5(str(self.temp_h5file))
 
     def _init_files(self):
-        test_dir = Path(__file__).resolve().parent
-        assert test_dir.name == "tests"
+        assert self.tests_root_dir.name == "tests"
 
-        test_root = test_dir / self.compare_case
+        test_root = self.tests_root_dir / self.compare_case
         assert test_root.exists()
 
         self._get_hbn_data(str(test_root))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -10,14 +10,9 @@ from .convert.regression_base import RegressTest as RegressTestBase
 
 
 class RegressTest(RegressTestBase):
-    def __init__(
-        self,
-        compare_case: str,
-        operations: List[str] = [],
-        activities: List[str] = [],
-        tcodes: List[str] = ["2"],
-        ids: List[str] = [],
-        threads: int = os.cpu_count() - 1,
+    def __init__(self,  compare_case: str, operations: List[str] = [],
+        activities: List[str] = [], tcodes: List[str] = ["2"],
+        ids: List[str] = [], threads: int = os.cpu_count() - 1,
         tests_root_dir = None
     ) -> None:
         if tests_root_dir is None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 import pytest
 from hsp2.hsp2tools.commands import import_uci, run

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from hsp2.hsp2tools.commands import import_uci, run
 from hsp2.hsp2tools.HDF5 import HDF5
+from typing import Dict, List, Tuple, Union
 
 from .convert.regression_base import RegressTest as RegressTestBase
 


### PR DESCRIPTION
TEST ONLY - NOT FOR MERGER

#### How To View Test Outputs
```
# Note: This code must be run from the tests dir due to importing
# the `convert` directory where the regression_base file lives
import numpy as np
from convert.regression_base import RegressTest

case = "test10specl"
base_case = "test10"
#case = "testcbp"
tdir = "/opt/model/HSPsquared/tests"
# can run this from here or command prompt as needed
#import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
#run(temp_specl_h5file, saveall=True, compress=False)

############# RegressTest data loader
## TEST CASE
test = RegressTest(case, threads=1)
# test object hydr
rchres_hydr_hsp2_test_table = test.hsp2_data._read_table('RCHRES', '001', 'HYDR')
perlnd_pwat_hsp2_test_table = test.hsp2_data._read_table('PERLND', '001', 'PWATER')
rchres_hydr_hsp2_test = test.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
rchres_hydr_hspf_test = test.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2)) #Note: the order of arguments is wonky in Regressbase
rchres_hydr_hsp2_test_mo = rchres_hydr_hsp2_test.resample('MS').mean()
rchres_hydr_hspf_test_mo = rchres_hydr_hspf_test.resample('MS').mean()
## BASE CASE
base = RegressTest(base_case, threads=1)
# base object hydr
rchres_hydr_hsp2_base_table = base.hsp2_data._read_table('RCHRES', '001', 'HYDR')
perlnd_pwat_hsp2_base_table = base.hsp2_data._read_table('PERLND', '001', 'PWATER')
rchres_hydr_hsp2_base = base.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
rchres_hydr_hspf_base = base.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2))  #Note: the order of arguments is wonky in Regressbase
rchres_hydr_hsp2_base_mo = rchres_hydr_hsp2_base.resample('MS').mean()
rchres_hydr_hspf_base_mo = rchres_hydr_hspf_base.resample('MS').mean()

# Show quantiles
np.quantile(rchres_hydr_hsp2_test, [0,0.25,0.5,0.75,1.0])
np.quantile(rchres_hydr_hspf_test, [0,0.25,0.5,0.75,1.0])
np.quantile(rchres_hydr_hsp2_base, [0,0.25,0.5,0.75,1.0])
np.quantile(rchres_hydr_hspf_base, [0,0.25,0.5,0.75,1.0])
# Monthly mean value comparisons
rchres_hydr_hsp2_test_mo
rchres_hydr_hspf_test_mo
rchres_hydr_hsp2_base_mo
rchres_hydr_hspf_base_mo

# Compare ANY arbitrary timeseries, not just the ones coded into the RegressTest object
# 3rd argument is tolerance to use
tol = 10.0
test.compare_time_series(rchres_hydr_hsp2_base_table['RO'], rchres_hydr_hsp2_test_table['RO'], tol)
# Example:  (True, 8.7855425)

# Compare inflows and outflows
np.mean(perlnd_pwat_hsp2_test_table['PERO']) * 6000 * 0.0833
np.mean(rchres_hydr_hsp2_test_table['IVOL'])
np.mean(rchres_hydr_hsp2_test_table['ROVOL'])
np.mean(perlnd_pwat_hsp2_base_table['PERO']) * 6000 * 0.0833
np.mean(rchres_hydr_hsp2_base_table['IVOL'])
np.mean(rchres_hydr_hsp2_base_table['ROVOL'])

# now do a comparison
# HYDR diff should be almost nonexistent
test.check_con(params = ('RCHRES', 'HYDR', '001', 'ROVOL', 2))
# this is very large for PWTGAS
test.check_con(params = ('PERLND', 'PWTGAS', '001', 'POHT', '2'))\
# Other mismatches in PERLND
test.check_con(params = ('PERLND', 'PWATER', '001', 'AGWS', '2'))
test.check_con(params = ('PERLND', 'PWATER', '001', 'PERO', '2'))
# Now run the full test
results = test.run_test()
found = False
mismatches = []
for key, results in results.items():
    no_data_hsp2, no_data_hspf, match, diff = results
    if any([no_data_hsp2, no_data_hspf]):
        continue
    if not match:
        mismatches.append((case, key, results))
    found = True
assert found

if mismatches:
    for case, key, results in mismatches:
        _, _, _, diff = results
        print(case, key, f"{diff:0.00%}")
    raise ValueError("results don't match hspf output")


```