### PR TITLE
Develop close1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   # Running HSP2
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
-  - pandas
+  - pandas <3.0
   - numba
   - numpy
   - hdf5

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -12,7 +12,7 @@ dependencies:
   # Running HSP2
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
-  - pandas >=2.0
+  - pandas >=2.0,<3.0
   - numba
   - numpy
   - hdf5

--- a/examples/state_specl_ops/update_pandas.py
+++ b/examples/state_specl_ops/update_pandas.py
@@ -1,0 +1,89 @@
+
+from numpy import float64
+from pandas import DataFrame, date_range
+from pandas.tseries.offsets import Minute
+from datetime import datetime as dt
+from typing import Union
+import os
+# NOte: to import HDF5 here, we must first import Model and Category or an error results...
+#       maybe that means there is work to be done on theose.
+from hsp2.hsp2.model import Model
+from hsp2.hsp2io.protocols import Category
+from hsp2.hsp2io.hdf import HDF5
+from hsp2.hsp2.utilities import (
+    versions,
+    get_timeseries,
+    expand_timeseries_names,
+    save_timeseries,
+    get_gener_timeseries,
+    hoursval
+)
+from hsp2.hsp2.configuration import activities, noop, expand_masslinks
+from hsp2.hsp2.state import (
+    init_state_dicts,
+    state_siminfo_hsp2,
+    state_load_dynamics_hsp2,
+    state_init_hsp2,
+    state_context_hsp2,
+)
+from hsp2.hsp2.om import (
+    om_init_state,
+    state_om_model_run_prep,
+    state_load_dynamics_om,
+    state_om_model_run_finish,
+)
+from hsp2.hsp2.SPECL import specl_load_state
+
+from hsp2.hsp2io.io import IOManager, SupportsReadTS, Category
+fpath = "./tests/test10/HSP2results/test10.h5"
+# try also:
+# fpath = './tests/testcbp/HSP2results/JL1_6562_6560.h5'
+# sometimes when testing you may need to close the file, so try:
+# f = h5py.File(fpath,'a') # use mode 'a' which allows read, write, modify
+# # f.close()
+hdf5_instance = HDF5(fpath)
+io_manager = IOManager(hdf5_instance)
+
+# Begin code from main.py
+parameter_obj = io_manager.read_parameters()
+opseq = parameter_obj.opseq
+ddlinks = parameter_obj.ddlinks
+ddmasslinks = parameter_obj.ddmasslinks
+ddext_sources = parameter_obj.ddext_sources
+ddgener = parameter_obj.ddgener
+model = parameter_obj.model
+siminfo = parameter_obj.siminfo
+ftables = parameter_obj.ftables
+specactions = parameter_obj.specactions
+monthdata = parameter_obj.monthdata
+
+start, stop = siminfo["start"], siminfo["stop"]
+
+copy_instances = {}
+gener_instances = {}
+
+#######################################################################################
+# initialize STATE dicts
+#######################################################################################
+# Set up Things in state that will be used in all modular activities like SPECL
+state = init_state_dicts()
+state_siminfo_hsp2(parameter_obj, siminfo, io_manager, state)
+# Add support for dynamic functions to operate on STATE
+# - Load any dynamic components if present, and store variables on objects
+state_load_dynamics_hsp2(state, io_manager, siminfo)
+# Iterate through all segments and add crucial paths to state
+# before loading dynamic components that may reference them
+state_init_hsp2(state, opseq, activities)
+# - finally stash specactions in state, not domain (segment) dependent so do it once
+state["specactions"] = specactions  # stash the specaction dict in state
+om_init_state(state)  # set up operational model specific state entries
+specl_load_state(state, io_manager, siminfo)  # traditional special actions
+state_load_dynamics_om(
+    state, io_manager, siminfo
+)  # operational model for custom python
+# finalize all dynamically loaded components and prepare to run the model
+state_om_model_run_prep(state, io_manager, siminfo)
+#######################################################################################
+
+# main processing loop
+msg(1, f"Simulation Start: {start}, Stop: {stop}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "cltoolbox",
     "numba",
     "numpy<2.0",
-    "pandas",
+    "pandas<3.0",
     "tables",
     "pyparsing"
 ]

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -14,7 +14,7 @@ import pandas as pd
 from numba import types
 from numba.typed import Dict
 from numpy import float64, full, tile, zeros
-from pandas import Series, date_range
+from pandas import Series, date_range, Timedelta
 from pandas.tseries.offsets import Minute
 
 from hsp2.hsp2io.protocols import Category, SupportsReadTS, SupportsWriteTS
@@ -213,8 +213,9 @@ def transform(ts, name, how, siminfo):
     NOTE: these routines work for both regular and sparse timeseries input
     """
 
-    tsfreq = ts.index.freq
-    freq = Minute(siminfo["delt"])
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
     stop = siminfo["stop"]
 
     # append duplicate of last point to force processing last full interval
@@ -226,7 +227,7 @@ def transform(ts, name, how, siminfo):
     elif tsfreq is None:  # Sparse time base, frequency not defined
         ts = ts.reindex(siminfo["tbase"]).ffill().bfill()
     elif how == "SAME":
-        ts = ts.resample(freq).ffill()  # tsfreq >= freq assumed, or bad user choice
+        ts = ts.resample(fmins).ffill()  # tsfreq >= freq assumed, or bad user choice
     elif not how:
         if name in flowtype:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
@@ -236,24 +237,24 @@ def transform(ts, name, how, siminfo):
                     ratio = 1.0 / 8766.0
                 else:
                     ratio = freq / tsfreq
-                ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+                ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
             else:
-                ts = ts.resample(freq).sum()
+                ts = ts.resample(fmins).sum()
         else:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
-                ts = ts.resample(freq).ffill()
+                ts = ts.resample(fmins).ffiio_managerll()
             else:
-                ts = ts.resample(freq).mean()
+                ts = ts.resample(fmins).mean()
     elif how == "MEAN":
-        ts = ts.resample(freq).mean()
+        ts = ts.resample(fmins).mean()
     elif how == "SUM":
-        ts = ts.resample(freq).sum()
+        ts = ts.resample(fmins).sum()
     elif how == "MAX":
-        ts = ts.resample(freq).max()
+        ts = ts.resample(fmins).max()
     elif how == "MIN":
-        ts = ts.resample(freq).min()
+        ts = ts.resample(fmins).min()
     elif how == "LAST":
-        ts = ts.resample(freq).ffill()
+        ts = ts.resample(fmins).ffill()
     elif how == "DIV":
         if "Y" in str(tsfreq) or "M" in str(tsfreq):
             mult = 1
@@ -268,13 +269,13 @@ def transform(ts, name, how, siminfo):
                 ratio = 1.0 / (8766.0 * mult)
             else:
                 ratio = freq / tsfreq
-            ts = (ratio * ts).resample(freq).ffill()  # HSP2 how = div
+            ts = (ratio * ts).resample(fmins).ffill()  # HSP2 how = div
         else:
-            ts = (ts * (freq / ts.index.freq)).resample(freq).ffill()
+            ts = (ts * (freq / tsfreq)).resample(fmins).ffill()
     elif how == "ZEROFILL":
-        ts = ts.resample(freq).fillna(0.0)
+        ts = ts.resample(fmins).fillna(0.0)
     elif how == "INTERPOLATE":
-        ts = ts.resample(freq).interpolate()
+        ts = ts.resample(fmins).interpolate()
     else:
         print(f"UNKNOWN method in TRANS, {how}")
         return zeros(1)
@@ -287,7 +288,8 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
     """create hours flags, flag on the hour or lapse table over full simulation"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     dr = date_range(
         start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq=Minute(60)
@@ -297,16 +299,17 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
         hours[0] = 1
 
     ts = Series(hours[0 : len(dr)], dr)
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
     if lapselike:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().ffill()
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).mean()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().ffill()
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).mean()
     else:
-        if ts.index.freq > freq:  # upsample
-            ts = ts.resample(freq).asfreq().fillna(0.0)
-        elif ts.index.freq < freq:  # downsample
-            ts = ts.resample(freq).max()
+        if tsfreq > freq:  # upsample
+            ts = ts.resample(fmins).asfreq().fillna(0.0)
+        elif tsfreq < freq:  # downsample
+            ts = ts.resample(fmins).max()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -321,16 +324,18 @@ def monthval(siminfo, monthly):
     """returns value at start of month for all times within the month"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").ffill()
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).asfreq().ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).asfreq().ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -339,16 +344,19 @@ def dayval(siminfo, monthly):
     interpolation to day, but constant within day"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").interpolate("time")
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -14,7 +14,7 @@ import pandas as pd
 from numba import types
 from numba.typed import Dict
 from numpy import float64, full, tile, zeros
-from pandas import Series, date_range, Timedelta
+from pandas import Series, date_range
 from pandas.tseries.offsets import Minute
 
 from hsp2.hsp2io.protocols import Category, SupportsReadTS, SupportsWriteTS
@@ -212,16 +212,16 @@ def transform(ts, name, how, siminfo):
          aggregate: MEAN, SUM, MAX, MIN
     NOTE: these routines work for both regular and sparse timeseries input
     """
-
+    
     tsfreq = Timedelta("1 " + ts.index.freqstr)
     fmins = Minute(siminfo["delt"])
     freq = Timedelta(fmins).to_timedelta64()
     stop = siminfo["stop"]
-
+    
     # append duplicate of last point to force processing last full interval
     if ts.index[-1] < stop:
         ts[stop] = ts.iloc[-1]
-
+    
     if freq == tsfreq:
         pass
     elif tsfreq is None:  # Sparse time base, frequency not defined
@@ -279,7 +279,7 @@ def transform(ts, name, how, siminfo):
     else:
         print(f"UNKNOWN method in TRANS, {how}")
         return zeros(1)
-
+    
     start, steps = siminfo["start"], siminfo["steps"]
     return ts[start:stop].to_numpy().astype(float64)[0:steps]
 
@@ -288,8 +288,7 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
     """create hours flags, flag on the hour or lapse table over full simulation"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    fmins = Minute(siminfo["delt"])
-    freq = Timedelta(fmins).to_timedelta64()
+    freq = Minute(siminfo["delt"])
 
     dr = date_range(
         start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq=Minute(60)
@@ -299,17 +298,16 @@ def hoursval(siminfo, hours24, dofirst=False, lapselike=False):
         hours[0] = 1
 
     ts = Series(hours[0 : len(dr)], dr)
-    tsfreq = Timedelta("1 " + ts.index.freqstr)
     if lapselike:
-        if tsfreq > freq:  # upsample
-            ts = ts.resample(fmins).asfreq().ffill()
-        elif tsfreq < freq:  # downsample
-            ts = ts.resample(fmins).mean()
+        if ts.index.freq > freq:  # upsample
+            ts = ts.resample(freq).asfreq().ffill()
+        elif ts.index.freq < freq:  # downsample
+            ts = ts.resample(freq).mean()
     else:
-        if tsfreq > freq:  # upsample
-            ts = ts.resample(fmins).asfreq().fillna(0.0)
-        elif tsfreq < freq:  # downsample
-            ts = ts.resample(fmins).max()
+        if ts.index.freq > freq:  # upsample
+            ts = ts.resample(freq).asfreq().fillna(0.0)
+        elif ts.index.freq < freq:  # downsample
+            ts = ts.resample(freq).max()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -324,18 +322,16 @@ def monthval(siminfo, monthly):
     """returns value at start of month for all times within the month"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    fmins = Minute(siminfo["delt"])
-    freq = Timedelta(fmins).to_timedelta64()
+    freq = Minute(siminfo["delt"])
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").ffill()
-    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if tsfreq > freq:  # upsample
-        ts = ts.resample(fmins).asfreq().ffill()
-    elif tsfreq < freq:  # downsample
-        ts = ts.resample(fmins).mean()
+    if ts.index.freq > freq:  # upsample
+        ts = ts.resample(freq).asfreq().ffill()
+    elif ts.index.freq < freq:  # downsample
+        ts = ts.resample(freq).mean()
     return ts.truncate(start, stop).to_numpy()
 
 
@@ -344,19 +340,16 @@ def dayval(siminfo, monthly):
     interpolation to day, but constant within day"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    fmins = Minute(siminfo["delt"])
-    freq = Timedelta(fmins).to_timedelta64()
+    freq = Minute(siminfo["delt"])
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").interpolate("time")
-    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-
-    if tsfreq > freq:  # upsample
-        ts = ts.resample(fmins).ffill()
-    elif tsfreq < freq:  # downsample
-        ts = ts.resample(fmins).mean()
+    if ts.index.freq > freq:  # upsample
+        ts = ts.resample(freq).ffill()
+    elif ts.index.freq < freq:  # downsample
+        ts = ts.resample(freq).mean()
     return ts.truncate(start, stop).to_numpy()
 
 

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -242,7 +242,7 @@ def transform(ts, name, how, siminfo):
                 ts = ts.resample(fmins).sum()
         else:
             if "Y" in str(tsfreq) or "M" in str(tsfreq) or tsfreq > freq:
-                ts = ts.resample(fmins).ffiio_managerll()
+                ts = ts.resample(fmins).ffill()
             else:
                 ts = ts.resample(fmins).mean()
     elif how == "MEAN":

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -322,16 +322,18 @@ def monthval(siminfo, monthly):
     """returns value at start of month for all times within the month"""
     start = siminfo["start"]
     stop = siminfo["stop"]
-    freq = Minute(siminfo["delt"])
+    fmins = Minute(siminfo["delt"])
+    freq = Timedelta(fmins).to_timedelta64()
 
     months = tile(monthly, stop.year - start.year + 1).astype(float)
     dr = date_range(start=f"{start.year}-01-01", end=f"{stop.year}-12-31", freq="MS")
     ts = Series(months, index=dr).resample("D").ffill()
+    tsfreq = Timedelta("1 " + ts.index.freqstr)
 
-    if ts.index.freq > freq:  # upsample
-        ts = ts.resample(freq).asfreq().ffill()
-    elif ts.index.freq < freq:  # downsample
-        ts = ts.resample(freq).mean()
+    if tsfreq > freq:  # upsample
+        ts = ts.resample(fmins).asfreq().ffill()
+    elif tsfreq < freq:  # downsample
+        ts = ts.resample(fmins).mean()
     return ts.truncate(start, stop).to_numpy()
 
 

--- a/src/hsp2/hsp2/utilities.py
+++ b/src/hsp2/hsp2/utilities.py
@@ -14,7 +14,7 @@ import pandas as pd
 from numba import types
 from numba.typed import Dict
 from numpy import float64, full, tile, zeros
-from pandas import Series, date_range
+from pandas import Series, date_range, Timedelta
 from pandas.tseries.offsets import Minute
 
 from hsp2.hsp2io.protocols import Category, SupportsReadTS, SupportsWriteTS

--- a/src/hsp2/hsp2io/hdf.py
+++ b/src/hsp2/hsp2io/hdf.py
@@ -13,8 +13,11 @@ class HDF5:
         self._store = pd.HDFStore(file_path)
         None
 
-    def __del__(self):
+    def close(self):
         self._store.close()
+
+    def __del__(self):
+        self.close()
 
     def __enter__(self):
         return self

--- a/src/hsp2/hsp2tools/commands.py
+++ b/src/hsp2/hsp2tools/commands.py
@@ -24,6 +24,7 @@ def run(h5file, saveall=True, compress=True):
     hdf5_instance = HDF5(h5file)
     io_manager = IOManager(hdf5_instance)
     main(io_manager, saveall=saveall, jupyterlab=compress)
+    hdf5_instance.close()
 
 
 def import_uci(ucifile, h5file):

--- a/tests/cmd_regression.py
+++ b/tests/cmd_regression.py
@@ -1,0 +1,88 @@
+# Note: This code must be run from the tests dir due to importing
+# the `convert` directory where the regression_base file lives
+# todo: make this convert path passable by argument 
+import numpy as np
+from convert.regression_base import RegressTest
+
+case = "test10specl"
+base_case = "test10"
+#case = "testcbp"
+tdir = "/opt/model/HSPsquared/tests"
+#import_uci(str(hsp2_specl_uci), str(temp_specl_h5file))
+#run(temp_specl_h5file, saveall=True, compress=False)
+
+############# RegressTest data loader
+## TEST CASE
+test = RegressTest(case, threads=1)
+# test object hydr
+rchres_hydr_hsp2_test_table = test.hsp2_data._read_table('RCHRES', '001', 'HYDR')
+perlnd_pwat_hsp2_test_table = test.hsp2_data._read_table('PERLND', '001', 'PWATER')
+rchres_hydr_hsp2_test = test.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
+rchres_hydr_hspf_test = test.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2)) #Note: the order of arguments is wonky in Regressbase
+rchres_hydr_hsp2_test_mo = rchres_hydr_hsp2_test.resample('MS').mean()
+rchres_hydr_hspf_test_mo = rchres_hydr_hspf_test.resample('MS').mean()
+## BASE CASE
+base = RegressTest(base_case, threads=1)
+# base object hydr
+rchres_hydr_hsp2_base_table = base.hsp2_data._read_table('RCHRES', '001', 'HYDR')
+perlnd_pwat_hsp2_base_table = base.hsp2_data._read_table('PERLND', '001', 'PWATER')
+rchres_hydr_hsp2_base = base.hsp2_data.get_time_series('RCHRES', '001', 'RO', 'HYDR')
+rchres_hydr_hspf_base = base.get_hspf_time_series( ('RCHRES', 'HYDR', '001', 'RO', 2))  #Note: the order of arguments is wonky in Regressbase
+rchres_hydr_hsp2_base_mo = rchres_hydr_hsp2_base.resample('MS').mean()
+rchres_hydr_hspf_base_mo = rchres_hydr_hspf_base.resample('MS').mean()
+
+# Show quantiles
+print("hsp2", case, np.quantile(rchres_hydr_hsp2_test, [0,0.25,0.5,0.75,1.0]))
+print("hspf", case, np.quantile(rchres_hydr_hspf_test, [0,0.25,0.5,0.75,1.0]))
+print("hsp2", base_case, np.quantile(rchres_hydr_hsp2_base, [0,0.25,0.5,0.75,1.0]))
+print("hspf", base_case, np.quantile(rchres_hydr_hspf_base, [0,0.25,0.5,0.75,1.0]))
+# Monthly mean value comparisons
+rchres_hydr_hsp2_test_mo
+rchres_hydr_hspf_test_mo
+rchres_hydr_hsp2_base_mo
+rchres_hydr_hspf_base_mo
+
+# Compare ANY arbitrary timeseries, not just the ones coded into the RegressTest object
+# 3rd argument is tolerance to use
+tol = 10.0
+test.compare_time_series(rchres_hydr_hsp2_base_table['RO'], rchres_hydr_hsp2_test_table['RO'], tol)
+# Example:  (True, 8.7855425)
+
+# Compare inflows and outflows
+np.mean(perlnd_pwat_hsp2_test_table['PERO']) * 6000 * 0.0833
+np.mean(rchres_hydr_hsp2_test_table['IVOL'])
+np.mean(rchres_hydr_hsp2_test_table['ROVOL'])
+np.mean(perlnd_pwat_hsp2_base_table['PERO']) * 6000 * 0.0833
+np.mean(rchres_hydr_hsp2_base_table['IVOL'])
+np.mean(rchres_hydr_hsp2_base_table['ROVOL'])
+
+# now do a comparison
+# HYDR diff should be almost nonexistent
+test.check_con(params = ('RCHRES', 'HYDR', '001', 'ROVOL', 2))
+# this is very large for PWTGAS
+# git: test10specl ('PERLND', 'PWTGAS', '001', 'POHT', '2') 1163640%
+test.check_con(params = ('PERLND', 'PWTGAS', '001', 'POHT', '2'))
+# Other mismatches in PERLND
+test.check_con(params = ('PERLND', 'PWATER', '001', 'AGWS', '2'))
+test.check_con(params = ('PERLND', 'PWATER', '001', 'PERO', '2'))
+# Now run the full test
+test.quiet = True # this lets us test without overwhelming the console
+results = test.run_test()
+found = False
+mismatches = []
+for key, results in results.items():
+    no_data_hsp2, no_data_hspf, match, diff = results
+    if any([no_data_hsp2, no_data_hspf]):
+        continue
+    if not match:
+        mismatches.append((case, key, results))
+    found = True
+
+print(mismatches)
+
+if mismatches:
+    for case, key, results in mismatches:
+        diff = results
+        print(case, key, f"{diff:0.00%}")
+else:
+    print("No mismatches found. Success!")

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -30,7 +30,7 @@ class RegressTest:
         self.tcodes = tcodes
         self.ids = ids
         self.threads = threads
-
+        self.quiet = False # allows users to set this later
         self._init_files()
 
     def _init_files(self):
@@ -185,7 +185,8 @@ class RegressTest:
     def check_con(self, params: OperationsTuple) -> ResultsTuple:
         """Performs comparision of single constituent"""
         operation, activity, id, constituent, tcode = params
-        print(f"    {operation}_{id}  {activity}  {constituent}\n")
+        if not self.quiet:
+            print(f"    {operation}_{id}  {activity}  {constituent}\n")
 
         ts_hsp2 = self.hsp2_data.get_time_series(operation, id, constituent, activity)
         ts_hspf = self.get_hspf_time_series(params)

--- a/tests/testcbp/HSP2results/PL3_5250_0001.json
+++ b/tests/testcbp/HSP2results/PL3_5250_0001.json
@@ -1,0 +1,2515 @@
+{
+    "RCHRES_R001": {
+        "name": "RCHRES_R001",
+        "object_class": "ModelObject",
+        "value": "0",
+        "wd_1": {
+            "name": "wd_1",
+            "object_class": "Equation",
+            "value": "0.0 + 0.0"
+        },
+        "wd_2": {
+            "name": "wd_2",
+            "object_class": "Equation",
+            "value": "0.0 + wd_1"
+        },
+        "wd_3": {
+            "name": "wd_3",
+            "object_class": "Equation",
+            "value": "0.0 + wd_2"
+        },
+        "wd_4": {
+            "name": "wd_4",
+            "object_class": "Equation",
+            "value": "0.0 + wd_3"
+        },
+        "wd_5": {
+            "name": "wd_5",
+            "object_class": "Equation",
+            "value": "0.0 + wd_4"
+        },
+        "wd_6": {
+            "name": "wd_6",
+            "object_class": "Equation",
+            "value": "0.0 + wd_5"
+        },
+        "wd_7": {
+            "name": "wd_7",
+            "object_class": "Equation",
+            "value": "0.0 + wd_6"
+        },
+        "wd_8": {
+            "name": "wd_8",
+            "object_class": "Equation",
+            "value": "0.0 + wd_7"
+        },
+        "wd_9": {
+            "name": "wd_9",
+            "object_class": "Equation",
+            "value": "0.0 + wd_8"
+        },
+        "wd_10": {
+            "name": "wd_10",
+            "object_class": "Equation",
+            "value": "0.0 + wd_9"
+        },
+        "wd_11": {
+            "name": "wd_11",
+            "object_class": "Equation",
+            "value": "0.0 + wd_10"
+        },
+        "wd_12": {
+            "name": "wd_12",
+            "object_class": "Equation",
+            "value": "0.0 + wd_11"
+        },
+        "wd_13": {
+            "name": "wd_13",
+            "object_class": "Equation",
+            "value": "0.0 + wd_12"
+        },
+        "wd_14": {
+            "name": "wd_14",
+            "object_class": "Equation",
+            "value": "0.0 + wd_13"
+        },
+        "wd_15": {
+            "name": "wd_15",
+            "object_class": "Equation",
+            "value": "0.0 + wd_14"
+        },
+        "wd_16": {
+            "name": "wd_16",
+            "object_class": "Equation",
+            "value": "0.0 + wd_15"
+        },
+        "wd_17": {
+            "name": "wd_17",
+            "object_class": "Equation",
+            "value": "0.0 + wd_16"
+        },
+        "wd_18": {
+            "name": "wd_18",
+            "object_class": "Equation",
+            "value": "0.0 + wd_17"
+        },
+        "wd_19": {
+            "name": "wd_19",
+            "object_class": "Equation",
+            "value": "0.0 + wd_18"
+        },
+        "wd_20": {
+            "name": "wd_20",
+            "object_class": "Equation",
+            "value": "0.0 + wd_19"
+        },
+        "wd_21": {
+            "name": "wd_21",
+            "object_class": "Equation",
+            "value": "0.0 + wd_20"
+        },
+        "wd_22": {
+            "name": "wd_22",
+            "object_class": "Equation",
+            "value": "0.0 + wd_21"
+        },
+        "wd_23": {
+            "name": "wd_23",
+            "object_class": "Equation",
+            "value": "0.0 + wd_22"
+        },
+        "wd_24": {
+            "name": "wd_24",
+            "object_class": "Equation",
+            "value": "0.0 + wd_23"
+        },
+        "wd_25": {
+            "name": "wd_25",
+            "object_class": "Equation",
+            "value": "0.0 + wd_24"
+        },
+        "wd_26": {
+            "name": "wd_26",
+            "object_class": "Equation",
+            "value": "0.0 + wd_25"
+        },
+        "wd_27": {
+            "name": "wd_27",
+            "object_class": "Equation",
+            "value": "0.0 + wd_26"
+        },
+        "wd_28": {
+            "name": "wd_28",
+            "object_class": "Equation",
+            "value": "0.0 + wd_27"
+        },
+        "wd_29": {
+            "name": "wd_29",
+            "object_class": "Equation",
+            "value": "0.0 + wd_28"
+        },
+        "wd_30": {
+            "name": "wd_30",
+            "object_class": "Equation",
+            "value": "0.0 + wd_29"
+        },
+        "wd_31": {
+            "name": "wd_31",
+            "object_class": "Equation",
+            "value": "0.0 + wd_30"
+        },
+        "wd_32": {
+            "name": "wd_32",
+            "object_class": "Equation",
+            "value": "0.0 + wd_31"
+        },
+        "wd_33": {
+            "name": "wd_33",
+            "object_class": "Equation",
+            "value": "0.0 + wd_32"
+        },
+        "wd_34": {
+            "name": "wd_34",
+            "object_class": "Equation",
+            "value": "0.0 + wd_33"
+        },
+        "wd_35": {
+            "name": "wd_35",
+            "object_class": "Equation",
+            "value": "0.0 + wd_34"
+        },
+        "wd_36": {
+            "name": "wd_36",
+            "object_class": "Equation",
+            "value": "0.0 + wd_35"
+        },
+        "wd_37": {
+            "name": "wd_37",
+            "object_class": "Equation",
+            "value": "0.0 + wd_36"
+        },
+        "wd_38": {
+            "name": "wd_38",
+            "object_class": "Equation",
+            "value": "0.0 + wd_37"
+        },
+        "wd_39": {
+            "name": "wd_39",
+            "object_class": "Equation",
+            "value": "0.0 + wd_38"
+        },
+        "wd_40": {
+            "name": "wd_40",
+            "object_class": "Equation",
+            "value": "0.0 + wd_39"
+        },
+        "wd_41": {
+            "name": "wd_41",
+            "object_class": "Equation",
+            "value": "0.0 + wd_40"
+        },
+        "wd_42": {
+            "name": "wd_42",
+            "object_class": "Equation",
+            "value": "0.0 + wd_41"
+        },
+        "wd_43": {
+            "name": "wd_43",
+            "object_class": "Equation",
+            "value": "0.0 + wd_42"
+        },
+        "wd_44": {
+            "name": "wd_44",
+            "object_class": "Equation",
+            "value": "0.0 + wd_43"
+        },
+        "wd_45": {
+            "name": "wd_45",
+            "object_class": "Equation",
+            "value": "0.0 + wd_44"
+        },
+        "wd_46": {
+            "name": "wd_46",
+            "object_class": "Equation",
+            "value": "0.0 + wd_45"
+        },
+        "wd_47": {
+            "name": "wd_47",
+            "object_class": "Equation",
+            "value": "0.0 + wd_46"
+        },
+        "wd_48": {
+            "name": "wd_48",
+            "object_class": "Equation",
+            "value": "0.0 + wd_47"
+        },
+        "wd_49": {
+            "name": "wd_49",
+            "object_class": "Equation",
+            "value": "0.0 + wd_48"
+        },
+        "wd_50": {
+            "name": "wd_50",
+            "object_class": "Equation",
+            "value": "0.0 + wd_49"
+        },
+        "wd_51": {
+            "name": "wd_51",
+            "object_class": "Equation",
+            "value": "0.0 + wd_50"
+        },
+        "wd_52": {
+            "name": "wd_52",
+            "object_class": "Equation",
+            "value": "0.0 + wd_51"
+        },
+        "wd_53": {
+            "name": "wd_53",
+            "object_class": "Equation",
+            "value": "0.0 + wd_52"
+        },
+        "wd_54": {
+            "name": "wd_54",
+            "object_class": "Equation",
+            "value": "0.0 + wd_53"
+        },
+        "wd_55": {
+            "name": "wd_55",
+            "object_class": "Equation",
+            "value": "0.0 + wd_54"
+        },
+        "wd_56": {
+            "name": "wd_56",
+            "object_class": "Equation",
+            "value": "0.0 + wd_55"
+        },
+        "wd_57": {
+            "name": "wd_57",
+            "object_class": "Equation",
+            "value": "0.0 + wd_56"
+        },
+        "wd_58": {
+            "name": "wd_58",
+            "object_class": "Equation",
+            "value": "0.0 + wd_57"
+        },
+        "wd_59": {
+            "name": "wd_59",
+            "object_class": "Equation",
+            "value": "0.0 + wd_58"
+        },
+        "wd_60": {
+            "name": "wd_60",
+            "object_class": "Equation",
+            "value": "0.0 + wd_59"
+        },
+        "wd_61": {
+            "name": "wd_61",
+            "object_class": "Equation",
+            "value": "0.0 + wd_60"
+        },
+        "wd_62": {
+            "name": "wd_62",
+            "object_class": "Equation",
+            "value": "0.0 + wd_61"
+        },
+        "wd_63": {
+            "name": "wd_63",
+            "object_class": "Equation",
+            "value": "0.0 + wd_62"
+        },
+        "wd_64": {
+            "name": "wd_64",
+            "object_class": "Equation",
+            "value": "0.0 + wd_63"
+        },
+        "wd_65": {
+            "name": "wd_65",
+            "object_class": "Equation",
+            "value": "0.0 + wd_64"
+        },
+        "wd_66": {
+            "name": "wd_66",
+            "object_class": "Equation",
+            "value": "0.0 + wd_65"
+        },
+        "wd_67": {
+            "name": "wd_67",
+            "object_class": "Equation",
+            "value": "0.0 + wd_66"
+        },
+        "wd_68": {
+            "name": "wd_68",
+            "object_class": "Equation",
+            "value": "0.0 + wd_67"
+        },
+        "wd_69": {
+            "name": "wd_69",
+            "object_class": "Equation",
+            "value": "0.0 + wd_68"
+        },
+        "wd_70": {
+            "name": "wd_70",
+            "object_class": "Equation",
+            "value": "0.0 + wd_69"
+        },
+        "wd_71": {
+            "name": "wd_71",
+            "object_class": "Equation",
+            "value": "0.0 + wd_70"
+        },
+        "wd_72": {
+            "name": "wd_72",
+            "object_class": "Equation",
+            "value": "0.0 + wd_71"
+        },
+        "wd_73": {
+            "name": "wd_73",
+            "object_class": "Equation",
+            "value": "0.0 + wd_72"
+        },
+        "wd_74": {
+            "name": "wd_74",
+            "object_class": "Equation",
+            "value": "0.0 + wd_73"
+        },
+        "wd_75": {
+            "name": "wd_75",
+            "object_class": "Equation",
+            "value": "0.0 + wd_74"
+        },
+        "wd_76": {
+            "name": "wd_76",
+            "object_class": "Equation",
+            "value": "0.0 + wd_75"
+        },
+        "wd_77": {
+            "name": "wd_77",
+            "object_class": "Equation",
+            "value": "0.0 + wd_76"
+        },
+        "wd_78": {
+            "name": "wd_78",
+            "object_class": "Equation",
+            "value": "0.0 + wd_77"
+        },
+        "wd_79": {
+            "name": "wd_79",
+            "object_class": "Equation",
+            "value": "0.0 + wd_78"
+        },
+        "wd_80": {
+            "name": "wd_80",
+            "object_class": "Equation",
+            "value": "0.0 + wd_79"
+        },
+        "wd_81": {
+            "name": "wd_81",
+            "object_class": "Equation",
+            "value": "0.0 + wd_80"
+        },
+        "wd_82": {
+            "name": "wd_82",
+            "object_class": "Equation",
+            "value": "0.0 + wd_81"
+        },
+        "wd_83": {
+            "name": "wd_83",
+            "object_class": "Equation",
+            "value": "0.0 + wd_82"
+        },
+        "wd_84": {
+            "name": "wd_84",
+            "object_class": "Equation",
+            "value": "0.0 + wd_83"
+        },
+        "wd_85": {
+            "name": "wd_85",
+            "object_class": "Equation",
+            "value": "0.0 + wd_84"
+        },
+        "wd_86": {
+            "name": "wd_86",
+            "object_class": "Equation",
+            "value": "0.0 + wd_85"
+        },
+        "wd_87": {
+            "name": "wd_87",
+            "object_class": "Equation",
+            "value": "0.0 + wd_86"
+        },
+        "wd_88": {
+            "name": "wd_88",
+            "object_class": "Equation",
+            "value": "0.0 + wd_87"
+        },
+        "wd_89": {
+            "name": "wd_89",
+            "object_class": "Equation",
+            "value": "0.0 + wd_88"
+        },
+        "wd_90": {
+            "name": "wd_90",
+            "object_class": "Equation",
+            "value": "0.0 + wd_89"
+        },
+        "wd_91": {
+            "name": "wd_91",
+            "object_class": "Equation",
+            "value": "0.0 + wd_90"
+        },
+        "wd_92": {
+            "name": "wd_92",
+            "object_class": "Equation",
+            "value": "0.0 + wd_91"
+        },
+        "wd_93": {
+            "name": "wd_93",
+            "object_class": "Equation",
+            "value": "0.0 + wd_92"
+        },
+        "wd_94": {
+            "name": "wd_94",
+            "object_class": "Equation",
+            "value": "0.0 + wd_93"
+        },
+        "wd_95": {
+            "name": "wd_95",
+            "object_class": "Equation",
+            "value": "0.0 + wd_94"
+        },
+        "wd_96": {
+            "name": "wd_96",
+            "object_class": "Equation",
+            "value": "0.0 + wd_95"
+        },
+        "wd_97": {
+            "name": "wd_97",
+            "object_class": "Equation",
+            "value": "0.0 + wd_96"
+        },
+        "wd_98": {
+            "name": "wd_98",
+            "object_class": "Equation",
+            "value": "0.0 + wd_97"
+        },
+        "wd_99": {
+            "name": "wd_99",
+            "object_class": "Equation",
+            "value": "0.0 + wd_98"
+        },
+        "wd_100": {
+            "name": "wd_100",
+            "object_class": "Equation",
+            "value": "0.0 + wd_99"
+        },
+        "wd_101": {
+            "name": "wd_101",
+            "object_class": "Equation",
+            "value": "0.0 + wd_100"
+        },
+        "wd_102": {
+            "name": "wd_102",
+            "object_class": "Equation",
+            "value": "0.0 + wd_101"
+        },
+        "wd_103": {
+            "name": "wd_103",
+            "object_class": "Equation",
+            "value": "0.0 + wd_102"
+        },
+        "wd_104": {
+            "name": "wd_104",
+            "object_class": "Equation",
+            "value": "0.0 + wd_103"
+        },
+        "wd_105": {
+            "name": "wd_105",
+            "object_class": "Equation",
+            "value": "0.0 + wd_104"
+        },
+        "wd_106": {
+            "name": "wd_106",
+            "object_class": "Equation",
+            "value": "0.0 + wd_105"
+        },
+        "wd_107": {
+            "name": "wd_107",
+            "object_class": "Equation",
+            "value": "0.0 + wd_106"
+        },
+        "wd_108": {
+            "name": "wd_108",
+            "object_class": "Equation",
+            "value": "0.0 + wd_107"
+        },
+        "wd_109": {
+            "name": "wd_109",
+            "object_class": "Equation",
+            "value": "0.0 + wd_108"
+        },
+        "wd_110": {
+            "name": "wd_110",
+            "object_class": "Equation",
+            "value": "0.0 + wd_109"
+        },
+        "wd_111": {
+            "name": "wd_111",
+            "object_class": "Equation",
+            "value": "0.0 + wd_110"
+        },
+        "wd_112": {
+            "name": "wd_112",
+            "object_class": "Equation",
+            "value": "0.0 + wd_111"
+        },
+        "wd_113": {
+            "name": "wd_113",
+            "object_class": "Equation",
+            "value": "0.0 + wd_112"
+        },
+        "wd_114": {
+            "name": "wd_114",
+            "object_class": "Equation",
+            "value": "0.0 + wd_113"
+        },
+        "wd_115": {
+            "name": "wd_115",
+            "object_class": "Equation",
+            "value": "0.0 + wd_114"
+        },
+        "wd_116": {
+            "name": "wd_116",
+            "object_class": "Equation",
+            "value": "0.0 + wd_115"
+        },
+        "wd_117": {
+            "name": "wd_117",
+            "object_class": "Equation",
+            "value": "0.0 + wd_116"
+        },
+        "wd_118": {
+            "name": "wd_118",
+            "object_class": "Equation",
+            "value": "0.0 + wd_117"
+        },
+        "wd_119": {
+            "name": "wd_119",
+            "object_class": "Equation",
+            "value": "0.0 + wd_118"
+        },
+        "wd_120": {
+            "name": "wd_120",
+            "object_class": "Equation",
+            "value": "0.0 + wd_119"
+        },
+        "wd_121": {
+            "name": "wd_121",
+            "object_class": "Equation",
+            "value": "0.0 + wd_120"
+        },
+        "wd_122": {
+            "name": "wd_122",
+            "object_class": "Equation",
+            "value": "0.0 + wd_121"
+        },
+        "wd_123": {
+            "name": "wd_123",
+            "object_class": "Equation",
+            "value": "0.0 + wd_122"
+        },
+        "wd_124": {
+            "name": "wd_124",
+            "object_class": "Equation",
+            "value": "0.0 + wd_123"
+        },
+        "wd_125": {
+            "name": "wd_125",
+            "object_class": "Equation",
+            "value": "0.0 + wd_124"
+        },
+        "wd_126": {
+            "name": "wd_126",
+            "object_class": "Equation",
+            "value": "0.0 + wd_125"
+        },
+        "wd_127": {
+            "name": "wd_127",
+            "object_class": "Equation",
+            "value": "0.0 + wd_126"
+        },
+        "wd_128": {
+            "name": "wd_128",
+            "object_class": "Equation",
+            "value": "0.0 + wd_127"
+        },
+        "wd_129": {
+            "name": "wd_129",
+            "object_class": "Equation",
+            "value": "0.0 + wd_128"
+        },
+        "wd_130": {
+            "name": "wd_130",
+            "object_class": "Equation",
+            "value": "0.0 + wd_129"
+        },
+        "wd_131": {
+            "name": "wd_131",
+            "object_class": "Equation",
+            "value": "0.0 + wd_130"
+        },
+        "wd_132": {
+            "name": "wd_132",
+            "object_class": "Equation",
+            "value": "0.0 + wd_131"
+        },
+        "wd_133": {
+            "name": "wd_133",
+            "object_class": "Equation",
+            "value": "0.0 + wd_132"
+        },
+        "wd_134": {
+            "name": "wd_134",
+            "object_class": "Equation",
+            "value": "0.0 + wd_133"
+        },
+        "wd_135": {
+            "name": "wd_135",
+            "object_class": "Equation",
+            "value": "0.0 + wd_134"
+        },
+        "wd_136": {
+            "name": "wd_136",
+            "object_class": "Equation",
+            "value": "0.0 + wd_135"
+        },
+        "wd_137": {
+            "name": "wd_137",
+            "object_class": "Equation",
+            "value": "0.0 + wd_136"
+        },
+        "wd_138": {
+            "name": "wd_138",
+            "object_class": "Equation",
+            "value": "0.0 + wd_137"
+        },
+        "wd_139": {
+            "name": "wd_139",
+            "object_class": "Equation",
+            "value": "0.0 + wd_138"
+        },
+        "wd_140": {
+            "name": "wd_140",
+            "object_class": "Equation",
+            "value": "0.0 + wd_139"
+        },
+        "wd_141": {
+            "name": "wd_141",
+            "object_class": "Equation",
+            "value": "0.0 + wd_140"
+        },
+        "wd_142": {
+            "name": "wd_142",
+            "object_class": "Equation",
+            "value": "0.0 + wd_141"
+        },
+        "wd_143": {
+            "name": "wd_143",
+            "object_class": "Equation",
+            "value": "0.0 + wd_142"
+        },
+        "wd_144": {
+            "name": "wd_144",
+            "object_class": "Equation",
+            "value": "0.0 + wd_143"
+        },
+        "wd_145": {
+            "name": "wd_145",
+            "object_class": "Equation",
+            "value": "0.0 + wd_144"
+        },
+        "wd_146": {
+            "name": "wd_146",
+            "object_class": "Equation",
+            "value": "0.0 + wd_145"
+        },
+        "wd_147": {
+            "name": "wd_147",
+            "object_class": "Equation",
+            "value": "0.0 + wd_146"
+        },
+        "wd_148": {
+            "name": "wd_148",
+            "object_class": "Equation",
+            "value": "0.0 + wd_147"
+        },
+        "wd_149": {
+            "name": "wd_149",
+            "object_class": "Equation",
+            "value": "0.0 + wd_148"
+        },
+        "wd_150": {
+            "name": "wd_150",
+            "object_class": "Equation",
+            "value": "0.0 + wd_149"
+        },
+        "wd_151": {
+            "name": "wd_151",
+            "object_class": "Equation",
+            "value": "0.0 + wd_150"
+        },
+        "wd_152": {
+            "name": "wd_152",
+            "object_class": "Equation",
+            "value": "0.0 + wd_151"
+        },
+        "wd_153": {
+            "name": "wd_153",
+            "object_class": "Equation",
+            "value": "0.0 + wd_152"
+        },
+        "wd_154": {
+            "name": "wd_154",
+            "object_class": "Equation",
+            "value": "0.0 + wd_153"
+        },
+        "wd_155": {
+            "name": "wd_155",
+            "object_class": "Equation",
+            "value": "0.0 + wd_154"
+        },
+        "wd_156": {
+            "name": "wd_156",
+            "object_class": "Equation",
+            "value": "0.0 + wd_155"
+        },
+        "wd_157": {
+            "name": "wd_157",
+            "object_class": "Equation",
+            "value": "0.0 + wd_156"
+        },
+        "wd_158": {
+            "name": "wd_158",
+            "object_class": "Equation",
+            "value": "0.0 + wd_157"
+        },
+        "wd_159": {
+            "name": "wd_159",
+            "object_class": "Equation",
+            "value": "0.0 + wd_158"
+        },
+        "wd_160": {
+            "name": "wd_160",
+            "object_class": "Equation",
+            "value": "0.0 + wd_159"
+        },
+        "wd_161": {
+            "name": "wd_161",
+            "object_class": "Equation",
+            "value": "0.0 + wd_160"
+        },
+        "wd_162": {
+            "name": "wd_162",
+            "object_class": "Equation",
+            "value": "0.0 + wd_161"
+        },
+        "wd_163": {
+            "name": "wd_163",
+            "object_class": "Equation",
+            "value": "0.0 + wd_162"
+        },
+        "wd_164": {
+            "name": "wd_164",
+            "object_class": "Equation",
+            "value": "0.0 + wd_163"
+        },
+        "wd_165": {
+            "name": "wd_165",
+            "object_class": "Equation",
+            "value": "0.0 + wd_164"
+        },
+        "wd_166": {
+            "name": "wd_166",
+            "object_class": "Equation",
+            "value": "0.0 + wd_165"
+        },
+        "wd_167": {
+            "name": "wd_167",
+            "object_class": "Equation",
+            "value": "0.0 + wd_166"
+        },
+        "wd_168": {
+            "name": "wd_168",
+            "object_class": "Equation",
+            "value": "0.0 + wd_167"
+        },
+        "wd_169": {
+            "name": "wd_169",
+            "object_class": "Equation",
+            "value": "0.0 + wd_168"
+        },
+        "wd_170": {
+            "name": "wd_170",
+            "object_class": "Equation",
+            "value": "0.0 + wd_169"
+        },
+        "wd_171": {
+            "name": "wd_171",
+            "object_class": "Equation",
+            "value": "0.0 + wd_170"
+        },
+        "wd_172": {
+            "name": "wd_172",
+            "object_class": "Equation",
+            "value": "0.0 + wd_171"
+        },
+        "wd_173": {
+            "name": "wd_173",
+            "object_class": "Equation",
+            "value": "0.0 + wd_172"
+        },
+        "wd_174": {
+            "name": "wd_174",
+            "object_class": "Equation",
+            "value": "0.0 + wd_173"
+        },
+        "wd_175": {
+            "name": "wd_175",
+            "object_class": "Equation",
+            "value": "0.0 + wd_174"
+        },
+        "wd_176": {
+            "name": "wd_176",
+            "object_class": "Equation",
+            "value": "0.0 + wd_175"
+        },
+        "wd_177": {
+            "name": "wd_177",
+            "object_class": "Equation",
+            "value": "0.0 + wd_176"
+        },
+        "wd_178": {
+            "name": "wd_178",
+            "object_class": "Equation",
+            "value": "0.0 + wd_177"
+        },
+        "wd_179": {
+            "name": "wd_179",
+            "object_class": "Equation",
+            "value": "0.0 + wd_178"
+        },
+        "wd_180": {
+            "name": "wd_180",
+            "object_class": "Equation",
+            "value": "0.0 + wd_179"
+        },
+        "wd_181": {
+            "name": "wd_181",
+            "object_class": "Equation",
+            "value": "0.0 + wd_180"
+        },
+        "wd_182": {
+            "name": "wd_182",
+            "object_class": "Equation",
+            "value": "0.0 + wd_181"
+        },
+        "wd_183": {
+            "name": "wd_183",
+            "object_class": "Equation",
+            "value": "0.0 + wd_182"
+        },
+        "wd_184": {
+            "name": "wd_184",
+            "object_class": "Equation",
+            "value": "0.0 + wd_183"
+        },
+        "wd_185": {
+            "name": "wd_185",
+            "object_class": "Equation",
+            "value": "0.0 + wd_184"
+        },
+        "wd_186": {
+            "name": "wd_186",
+            "object_class": "Equation",
+            "value": "0.0 + wd_185"
+        },
+        "wd_187": {
+            "name": "wd_187",
+            "object_class": "Equation",
+            "value": "0.0 + wd_186"
+        },
+        "wd_188": {
+            "name": "wd_188",
+            "object_class": "Equation",
+            "value": "0.0 + wd_187"
+        },
+        "wd_189": {
+            "name": "wd_189",
+            "object_class": "Equation",
+            "value": "0.0 + wd_188"
+        },
+        "wd_190": {
+            "name": "wd_190",
+            "object_class": "Equation",
+            "value": "0.0 + wd_189"
+        },
+        "wd_191": {
+            "name": "wd_191",
+            "object_class": "Equation",
+            "value": "0.0 + wd_190"
+        },
+        "wd_192": {
+            "name": "wd_192",
+            "object_class": "Equation",
+            "value": "0.0 + wd_191"
+        },
+        "wd_193": {
+            "name": "wd_193",
+            "object_class": "Equation",
+            "value": "0.0 + wd_192"
+        },
+        "wd_194": {
+            "name": "wd_194",
+            "object_class": "Equation",
+            "value": "0.0 + wd_193"
+        },
+        "wd_195": {
+            "name": "wd_195",
+            "object_class": "Equation",
+            "value": "0.0 + wd_194"
+        },
+        "wd_196": {
+            "name": "wd_196",
+            "object_class": "Equation",
+            "value": "0.0 + wd_195"
+        },
+        "wd_197": {
+            "name": "wd_197",
+            "object_class": "Equation",
+            "value": "0.0 + wd_196"
+        },
+        "wd_198": {
+            "name": "wd_198",
+            "object_class": "Equation",
+            "value": "0.0 + wd_197"
+        },
+        "wd_199": {
+            "name": "wd_199",
+            "object_class": "Equation",
+            "value": "0.0 + wd_198"
+        },
+        "wd_200": {
+            "name": "wd_200",
+            "object_class": "Equation",
+            "value": "0.0 + wd_199"
+        },
+        "wd_201": {
+            "name": "wd_201",
+            "object_class": "Equation",
+            "value": "0.0 + wd_200"
+        },
+        "wd_202": {
+            "name": "wd_202",
+            "object_class": "Equation",
+            "value": "0.0 + wd_201"
+        },
+        "wd_203": {
+            "name": "wd_203",
+            "object_class": "Equation",
+            "value": "0.0 + wd_202"
+        },
+        "wd_204": {
+            "name": "wd_204",
+            "object_class": "Equation",
+            "value": "0.0 + wd_203"
+        },
+        "wd_205": {
+            "name": "wd_205",
+            "object_class": "Equation",
+            "value": "0.0 + wd_204"
+        },
+        "wd_206": {
+            "name": "wd_206",
+            "object_class": "Equation",
+            "value": "0.0 + wd_205"
+        },
+        "wd_207": {
+            "name": "wd_207",
+            "object_class": "Equation",
+            "value": "0.0 + wd_206"
+        },
+        "wd_208": {
+            "name": "wd_208",
+            "object_class": "Equation",
+            "value": "0.0 + wd_207"
+        },
+        "wd_209": {
+            "name": "wd_209",
+            "object_class": "Equation",
+            "value": "0.0 + wd_208"
+        },
+        "wd_210": {
+            "name": "wd_210",
+            "object_class": "Equation",
+            "value": "0.0 + wd_209"
+        },
+        "wd_211": {
+            "name": "wd_211",
+            "object_class": "Equation",
+            "value": "0.0 + wd_210"
+        },
+        "wd_212": {
+            "name": "wd_212",
+            "object_class": "Equation",
+            "value": "0.0 + wd_211"
+        },
+        "wd_213": {
+            "name": "wd_213",
+            "object_class": "Equation",
+            "value": "0.0 + wd_212"
+        },
+        "wd_214": {
+            "name": "wd_214",
+            "object_class": "Equation",
+            "value": "0.0 + wd_213"
+        },
+        "wd_215": {
+            "name": "wd_215",
+            "object_class": "Equation",
+            "value": "0.0 + wd_214"
+        },
+        "wd_216": {
+            "name": "wd_216",
+            "object_class": "Equation",
+            "value": "0.0 + wd_215"
+        },
+        "wd_217": {
+            "name": "wd_217",
+            "object_class": "Equation",
+            "value": "0.0 + wd_216"
+        },
+        "wd_218": {
+            "name": "wd_218",
+            "object_class": "Equation",
+            "value": "0.0 + wd_217"
+        },
+        "wd_219": {
+            "name": "wd_219",
+            "object_class": "Equation",
+            "value": "0.0 + wd_218"
+        },
+        "wd_220": {
+            "name": "wd_220",
+            "object_class": "Equation",
+            "value": "0.0 + wd_219"
+        },
+        "wd_221": {
+            "name": "wd_221",
+            "object_class": "Equation",
+            "value": "0.0 + wd_220"
+        },
+        "wd_222": {
+            "name": "wd_222",
+            "object_class": "Equation",
+            "value": "0.0 + wd_221"
+        },
+        "wd_223": {
+            "name": "wd_223",
+            "object_class": "Equation",
+            "value": "0.0 + wd_222"
+        },
+        "wd_224": {
+            "name": "wd_224",
+            "object_class": "Equation",
+            "value": "0.0 + wd_223"
+        },
+        "wd_225": {
+            "name": "wd_225",
+            "object_class": "Equation",
+            "value": "0.0 + wd_224"
+        },
+        "wd_226": {
+            "name": "wd_226",
+            "object_class": "Equation",
+            "value": "0.0 + wd_225"
+        },
+        "wd_227": {
+            "name": "wd_227",
+            "object_class": "Equation",
+            "value": "0.0 + wd_226"
+        },
+        "wd_228": {
+            "name": "wd_228",
+            "object_class": "Equation",
+            "value": "0.0 + wd_227"
+        },
+        "wd_229": {
+            "name": "wd_229",
+            "object_class": "Equation",
+            "value": "0.0 + wd_228"
+        },
+        "wd_230": {
+            "name": "wd_230",
+            "object_class": "Equation",
+            "value": "0.0 + wd_229"
+        },
+        "wd_231": {
+            "name": "wd_231",
+            "object_class": "Equation",
+            "value": "0.0 + wd_230"
+        },
+        "wd_232": {
+            "name": "wd_232",
+            "object_class": "Equation",
+            "value": "0.0 + wd_231"
+        },
+        "wd_233": {
+            "name": "wd_233",
+            "object_class": "Equation",
+            "value": "0.0 + wd_232"
+        },
+        "wd_234": {
+            "name": "wd_234",
+            "object_class": "Equation",
+            "value": "0.0 + wd_233"
+        },
+        "wd_235": {
+            "name": "wd_235",
+            "object_class": "Equation",
+            "value": "0.0 + wd_234"
+        },
+        "wd_236": {
+            "name": "wd_236",
+            "object_class": "Equation",
+            "value": "0.0 + wd_235"
+        },
+        "wd_237": {
+            "name": "wd_237",
+            "object_class": "Equation",
+            "value": "0.0 + wd_236"
+        },
+        "wd_238": {
+            "name": "wd_238",
+            "object_class": "Equation",
+            "value": "0.0 + wd_237"
+        },
+        "wd_239": {
+            "name": "wd_239",
+            "object_class": "Equation",
+            "value": "0.0 + wd_238"
+        },
+        "wd_240": {
+            "name": "wd_240",
+            "object_class": "Equation",
+            "value": "0.0 + wd_239"
+        },
+        "wd_241": {
+            "name": "wd_241",
+            "object_class": "Equation",
+            "value": "0.0 + wd_240"
+        },
+        "wd_242": {
+            "name": "wd_242",
+            "object_class": "Equation",
+            "value": "0.0 + wd_241"
+        },
+        "wd_243": {
+            "name": "wd_243",
+            "object_class": "Equation",
+            "value": "0.0 + wd_242"
+        },
+        "wd_244": {
+            "name": "wd_244",
+            "object_class": "Equation",
+            "value": "0.0 + wd_243"
+        },
+        "wd_245": {
+            "name": "wd_245",
+            "object_class": "Equation",
+            "value": "0.0 + wd_244"
+        },
+        "wd_246": {
+            "name": "wd_246",
+            "object_class": "Equation",
+            "value": "0.0 + wd_245"
+        },
+        "wd_247": {
+            "name": "wd_247",
+            "object_class": "Equation",
+            "value": "0.0 + wd_246"
+        },
+        "wd_248": {
+            "name": "wd_248",
+            "object_class": "Equation",
+            "value": "0.0 + wd_247"
+        },
+        "wd_249": {
+            "name": "wd_249",
+            "object_class": "Equation",
+            "value": "0.0 + wd_248"
+        },
+        "wd_250": {
+            "name": "wd_250",
+            "object_class": "Equation",
+            "value": "0.0 + wd_249"
+        },
+        "wd_251": {
+            "name": "wd_251",
+            "object_class": "Equation",
+            "value": "0.0 + wd_250"
+        },
+        "wd_252": {
+            "name": "wd_252",
+            "object_class": "Equation",
+            "value": "0.0 + wd_251"
+        },
+        "wd_253": {
+            "name": "wd_253",
+            "object_class": "Equation",
+            "value": "0.0 + wd_252"
+        },
+        "wd_254": {
+            "name": "wd_254",
+            "object_class": "Equation",
+            "value": "0.0 + wd_253"
+        },
+        "wd_255": {
+            "name": "wd_255",
+            "object_class": "Equation",
+            "value": "0.0 + wd_254"
+        },
+        "wd_256": {
+            "name": "wd_256",
+            "object_class": "Equation",
+            "value": "0.0 + wd_255"
+        },
+        "wd_257": {
+            "name": "wd_257",
+            "object_class": "Equation",
+            "value": "0.0 + wd_256"
+        },
+        "wd_258": {
+            "name": "wd_258",
+            "object_class": "Equation",
+            "value": "0.0 + wd_257"
+        },
+        "wd_259": {
+            "name": "wd_259",
+            "object_class": "Equation",
+            "value": "0.0 + wd_258"
+        },
+        "wd_260": {
+            "name": "wd_260",
+            "object_class": "Equation",
+            "value": "0.0 + wd_259"
+        },
+        "wd_261": {
+            "name": "wd_261",
+            "object_class": "Equation",
+            "value": "0.0 + wd_260"
+        },
+        "wd_262": {
+            "name": "wd_262",
+            "object_class": "Equation",
+            "value": "0.0 + wd_261"
+        },
+        "wd_263": {
+            "name": "wd_263",
+            "object_class": "Equation",
+            "value": "0.0 + wd_262"
+        },
+        "wd_264": {
+            "name": "wd_264",
+            "object_class": "Equation",
+            "value": "0.0 + wd_263"
+        },
+        "wd_265": {
+            "name": "wd_265",
+            "object_class": "Equation",
+            "value": "0.0 + wd_264"
+        },
+        "wd_266": {
+            "name": "wd_266",
+            "object_class": "Equation",
+            "value": "0.0 + wd_265"
+        },
+        "wd_267": {
+            "name": "wd_267",
+            "object_class": "Equation",
+            "value": "0.0 + wd_266"
+        },
+        "wd_268": {
+            "name": "wd_268",
+            "object_class": "Equation",
+            "value": "0.0 + wd_267"
+        },
+        "wd_269": {
+            "name": "wd_269",
+            "object_class": "Equation",
+            "value": "0.0 + wd_268"
+        },
+        "wd_270": {
+            "name": "wd_270",
+            "object_class": "Equation",
+            "value": "0.0 + wd_269"
+        },
+        "wd_271": {
+            "name": "wd_271",
+            "object_class": "Equation",
+            "value": "0.0 + wd_270"
+        },
+        "wd_272": {
+            "name": "wd_272",
+            "object_class": "Equation",
+            "value": "0.0 + wd_271"
+        },
+        "wd_273": {
+            "name": "wd_273",
+            "object_class": "Equation",
+            "value": "0.0 + wd_272"
+        },
+        "wd_274": {
+            "name": "wd_274",
+            "object_class": "Equation",
+            "value": "0.0 + wd_273"
+        },
+        "wd_275": {
+            "name": "wd_275",
+            "object_class": "Equation",
+            "value": "0.0 + wd_274"
+        },
+        "wd_276": {
+            "name": "wd_276",
+            "object_class": "Equation",
+            "value": "0.0 + wd_275"
+        },
+        "wd_277": {
+            "name": "wd_277",
+            "object_class": "Equation",
+            "value": "0.0 + wd_276"
+        },
+        "wd_278": {
+            "name": "wd_278",
+            "object_class": "Equation",
+            "value": "0.0 + wd_277"
+        },
+        "wd_279": {
+            "name": "wd_279",
+            "object_class": "Equation",
+            "value": "0.0 + wd_278"
+        },
+        "wd_280": {
+            "name": "wd_280",
+            "object_class": "Equation",
+            "value": "0.0 + wd_279"
+        },
+        "wd_281": {
+            "name": "wd_281",
+            "object_class": "Equation",
+            "value": "0.0 + wd_280"
+        },
+        "wd_282": {
+            "name": "wd_282",
+            "object_class": "Equation",
+            "value": "0.0 + wd_281"
+        },
+        "wd_283": {
+            "name": "wd_283",
+            "object_class": "Equation",
+            "value": "0.0 + wd_282"
+        },
+        "wd_284": {
+            "name": "wd_284",
+            "object_class": "Equation",
+            "value": "0.0 + wd_283"
+        },
+        "wd_285": {
+            "name": "wd_285",
+            "object_class": "Equation",
+            "value": "0.0 + wd_284"
+        },
+        "wd_286": {
+            "name": "wd_286",
+            "object_class": "Equation",
+            "value": "0.0 + wd_285"
+        },
+        "wd_287": {
+            "name": "wd_287",
+            "object_class": "Equation",
+            "value": "0.0 + wd_286"
+        },
+        "wd_288": {
+            "name": "wd_288",
+            "object_class": "Equation",
+            "value": "0.0 + wd_287"
+        },
+        "wd_289": {
+            "name": "wd_289",
+            "object_class": "Equation",
+            "value": "0.0 + wd_288"
+        },
+        "wd_290": {
+            "name": "wd_290",
+            "object_class": "Equation",
+            "value": "0.0 + wd_289"
+        },
+        "wd_291": {
+            "name": "wd_291",
+            "object_class": "Equation",
+            "value": "0.0 + wd_290"
+        },
+        "wd_292": {
+            "name": "wd_292",
+            "object_class": "Equation",
+            "value": "0.0 + wd_291"
+        },
+        "wd_293": {
+            "name": "wd_293",
+            "object_class": "Equation",
+            "value": "0.0 + wd_292"
+        },
+        "wd_294": {
+            "name": "wd_294",
+            "object_class": "Equation",
+            "value": "0.0 + wd_293"
+        },
+        "wd_295": {
+            "name": "wd_295",
+            "object_class": "Equation",
+            "value": "0.0 + wd_294"
+        },
+        "wd_296": {
+            "name": "wd_296",
+            "object_class": "Equation",
+            "value": "0.0 + wd_295"
+        },
+        "wd_297": {
+            "name": "wd_297",
+            "object_class": "Equation",
+            "value": "0.0 + wd_296"
+        },
+        "wd_298": {
+            "name": "wd_298",
+            "object_class": "Equation",
+            "value": "0.0 + wd_297"
+        },
+        "wd_299": {
+            "name": "wd_299",
+            "object_class": "Equation",
+            "value": "0.0 + wd_298"
+        },
+        "wd_300": {
+            "name": "wd_300",
+            "object_class": "Equation",
+            "value": "0.0 + wd_299"
+        },
+        "wd_301": {
+            "name": "wd_301",
+            "object_class": "Equation",
+            "value": "0.0 + wd_300"
+        },
+        "wd_302": {
+            "name": "wd_302",
+            "object_class": "Equation",
+            "value": "0.0 + wd_301"
+        },
+        "wd_303": {
+            "name": "wd_303",
+            "object_class": "Equation",
+            "value": "0.0 + wd_302"
+        },
+        "wd_304": {
+            "name": "wd_304",
+            "object_class": "Equation",
+            "value": "0.0 + wd_303"
+        },
+        "wd_305": {
+            "name": "wd_305",
+            "object_class": "Equation",
+            "value": "0.0 + wd_304"
+        },
+        "wd_306": {
+            "name": "wd_306",
+            "object_class": "Equation",
+            "value": "0.0 + wd_305"
+        },
+        "wd_307": {
+            "name": "wd_307",
+            "object_class": "Equation",
+            "value": "0.0 + wd_306"
+        },
+        "wd_308": {
+            "name": "wd_308",
+            "object_class": "Equation",
+            "value": "0.0 + wd_307"
+        },
+        "wd_309": {
+            "name": "wd_309",
+            "object_class": "Equation",
+            "value": "0.0 + wd_308"
+        },
+        "wd_310": {
+            "name": "wd_310",
+            "object_class": "Equation",
+            "value": "0.0 + wd_309"
+        },
+        "wd_311": {
+            "name": "wd_311",
+            "object_class": "Equation",
+            "value": "0.0 + wd_310"
+        },
+        "wd_312": {
+            "name": "wd_312",
+            "object_class": "Equation",
+            "value": "0.0 + wd_311"
+        },
+        "wd_313": {
+            "name": "wd_313",
+            "object_class": "Equation",
+            "value": "0.0 + wd_312"
+        },
+        "wd_314": {
+            "name": "wd_314",
+            "object_class": "Equation",
+            "value": "0.0 + wd_313"
+        },
+        "wd_315": {
+            "name": "wd_315",
+            "object_class": "Equation",
+            "value": "0.0 + wd_314"
+        },
+        "wd_316": {
+            "name": "wd_316",
+            "object_class": "Equation",
+            "value": "0.0 + wd_315"
+        },
+        "wd_317": {
+            "name": "wd_317",
+            "object_class": "Equation",
+            "value": "0.0 + wd_316"
+        },
+        "wd_318": {
+            "name": "wd_318",
+            "object_class": "Equation",
+            "value": "0.0 + wd_317"
+        },
+        "wd_319": {
+            "name": "wd_319",
+            "object_class": "Equation",
+            "value": "0.0 + wd_318"
+        },
+        "wd_320": {
+            "name": "wd_320",
+            "object_class": "Equation",
+            "value": "0.0 + wd_319"
+        },
+        "wd_321": {
+            "name": "wd_321",
+            "object_class": "Equation",
+            "value": "0.0 + wd_320"
+        },
+        "wd_322": {
+            "name": "wd_322",
+            "object_class": "Equation",
+            "value": "0.0 + wd_321"
+        },
+        "wd_323": {
+            "name": "wd_323",
+            "object_class": "Equation",
+            "value": "0.0 + wd_322"
+        },
+        "wd_324": {
+            "name": "wd_324",
+            "object_class": "Equation",
+            "value": "0.0 + wd_323"
+        },
+        "wd_325": {
+            "name": "wd_325",
+            "object_class": "Equation",
+            "value": "0.0 + wd_324"
+        },
+        "wd_326": {
+            "name": "wd_326",
+            "object_class": "Equation",
+            "value": "0.0 + wd_325"
+        },
+        "wd_327": {
+            "name": "wd_327",
+            "object_class": "Equation",
+            "value": "0.0 + wd_326"
+        },
+        "wd_328": {
+            "name": "wd_328",
+            "object_class": "Equation",
+            "value": "0.0 + wd_327"
+        },
+        "wd_329": {
+            "name": "wd_329",
+            "object_class": "Equation",
+            "value": "0.0 + wd_328"
+        },
+        "wd_330": {
+            "name": "wd_330",
+            "object_class": "Equation",
+            "value": "0.0 + wd_329"
+        },
+        "wd_331": {
+            "name": "wd_331",
+            "object_class": "Equation",
+            "value": "0.0 + wd_330"
+        },
+        "wd_332": {
+            "name": "wd_332",
+            "object_class": "Equation",
+            "value": "0.0 + wd_331"
+        },
+        "wd_333": {
+            "name": "wd_333",
+            "object_class": "Equation",
+            "value": "0.0 + wd_332"
+        },
+        "wd_334": {
+            "name": "wd_334",
+            "object_class": "Equation",
+            "value": "0.0 + wd_333"
+        },
+        "wd_335": {
+            "name": "wd_335",
+            "object_class": "Equation",
+            "value": "0.0 + wd_334"
+        },
+        "wd_336": {
+            "name": "wd_336",
+            "object_class": "Equation",
+            "value": "0.0 + wd_335"
+        },
+        "wd_337": {
+            "name": "wd_337",
+            "object_class": "Equation",
+            "value": "0.0 + wd_336"
+        },
+        "wd_338": {
+            "name": "wd_338",
+            "object_class": "Equation",
+            "value": "0.0 + wd_337"
+        },
+        "wd_339": {
+            "name": "wd_339",
+            "object_class": "Equation",
+            "value": "0.0 + wd_338"
+        },
+        "wd_340": {
+            "name": "wd_340",
+            "object_class": "Equation",
+            "value": "0.0 + wd_339"
+        },
+        "wd_341": {
+            "name": "wd_341",
+            "object_class": "Equation",
+            "value": "0.0 + wd_340"
+        },
+        "wd_342": {
+            "name": "wd_342",
+            "object_class": "Equation",
+            "value": "0.0 + wd_341"
+        },
+        "wd_343": {
+            "name": "wd_343",
+            "object_class": "Equation",
+            "value": "0.0 + wd_342"
+        },
+        "wd_344": {
+            "name": "wd_344",
+            "object_class": "Equation",
+            "value": "0.0 + wd_343"
+        },
+        "wd_345": {
+            "name": "wd_345",
+            "object_class": "Equation",
+            "value": "0.0 + wd_344"
+        },
+        "wd_346": {
+            "name": "wd_346",
+            "object_class": "Equation",
+            "value": "0.0 + wd_345"
+        },
+        "wd_347": {
+            "name": "wd_347",
+            "object_class": "Equation",
+            "value": "0.0 + wd_346"
+        },
+        "wd_348": {
+            "name": "wd_348",
+            "object_class": "Equation",
+            "value": "0.0 + wd_347"
+        },
+        "wd_349": {
+            "name": "wd_349",
+            "object_class": "Equation",
+            "value": "0.0 + wd_348"
+        },
+        "wd_350": {
+            "name": "wd_350",
+            "object_class": "Equation",
+            "value": "0.0 + wd_349"
+        },
+        "wd_351": {
+            "name": "wd_351",
+            "object_class": "Equation",
+            "value": "0.0 + wd_350"
+        },
+        "wd_352": {
+            "name": "wd_352",
+            "object_class": "Equation",
+            "value": "0.0 + wd_351"
+        },
+        "wd_353": {
+            "name": "wd_353",
+            "object_class": "Equation",
+            "value": "0.0 + wd_352"
+        },
+        "wd_354": {
+            "name": "wd_354",
+            "object_class": "Equation",
+            "value": "0.0 + wd_353"
+        },
+        "wd_355": {
+            "name": "wd_355",
+            "object_class": "Equation",
+            "value": "0.0 + wd_354"
+        },
+        "wd_356": {
+            "name": "wd_356",
+            "object_class": "Equation",
+            "value": "0.0 + wd_355"
+        },
+        "wd_357": {
+            "name": "wd_357",
+            "object_class": "Equation",
+            "value": "0.0 + wd_356"
+        },
+        "wd_358": {
+            "name": "wd_358",
+            "object_class": "Equation",
+            "value": "0.0 + wd_357"
+        },
+        "wd_359": {
+            "name": "wd_359",
+            "object_class": "Equation",
+            "value": "0.0 + wd_358"
+        },
+        "wd_360": {
+            "name": "wd_360",
+            "object_class": "Equation",
+            "value": "0.0 + wd_359"
+        },
+        "wd_361": {
+            "name": "wd_361",
+            "object_class": "Equation",
+            "value": "0.0 + wd_360"
+        },
+        "wd_362": {
+            "name": "wd_362",
+            "object_class": "Equation",
+            "value": "0.0 + wd_361"
+        },
+        "wd_363": {
+            "name": "wd_363",
+            "object_class": "Equation",
+            "value": "0.0 + wd_362"
+        },
+        "wd_364": {
+            "name": "wd_364",
+            "object_class": "Equation",
+            "value": "0.0 + wd_363"
+        },
+        "wd_365": {
+            "name": "wd_365",
+            "object_class": "Equation",
+            "value": "0.0 + wd_364"
+        },
+        "wd_366": {
+            "name": "wd_366",
+            "object_class": "Equation",
+            "value": "0.0 + wd_365"
+        },
+        "wd_367": {
+            "name": "wd_367",
+            "object_class": "Equation",
+            "value": "0.0 + wd_366"
+        },
+        "wd_368": {
+            "name": "wd_368",
+            "object_class": "Equation",
+            "value": "0.0 + wd_367"
+        },
+        "wd_369": {
+            "name": "wd_369",
+            "object_class": "Equation",
+            "value": "0.0 + wd_368"
+        },
+        "wd_370": {
+            "name": "wd_370",
+            "object_class": "Equation",
+            "value": "0.0 + wd_369"
+        },
+        "wd_371": {
+            "name": "wd_371",
+            "object_class": "Equation",
+            "value": "0.0 + wd_370"
+        },
+        "wd_372": {
+            "name": "wd_372",
+            "object_class": "Equation",
+            "value": "0.0 + wd_371"
+        },
+        "wd_373": {
+            "name": "wd_373",
+            "object_class": "Equation",
+            "value": "0.0 + wd_372"
+        },
+        "wd_374": {
+            "name": "wd_374",
+            "object_class": "Equation",
+            "value": "0.0 + wd_373"
+        },
+        "wd_375": {
+            "name": "wd_375",
+            "object_class": "Equation",
+            "value": "0.0 + wd_374"
+        },
+        "wd_376": {
+            "name": "wd_376",
+            "object_class": "Equation",
+            "value": "0.0 + wd_375"
+        },
+        "wd_377": {
+            "name": "wd_377",
+            "object_class": "Equation",
+            "value": "0.0 + wd_376"
+        },
+        "wd_378": {
+            "name": "wd_378",
+            "object_class": "Equation",
+            "value": "0.0 + wd_377"
+        },
+        "wd_379": {
+            "name": "wd_379",
+            "object_class": "Equation",
+            "value": "0.0 + wd_378"
+        },
+        "wd_380": {
+            "name": "wd_380",
+            "object_class": "Equation",
+            "value": "0.0 + wd_379"
+        },
+        "wd_381": {
+            "name": "wd_381",
+            "object_class": "Equation",
+            "value": "0.0 + wd_380"
+        },
+        "wd_382": {
+            "name": "wd_382",
+            "object_class": "Equation",
+            "value": "0.0 + wd_381"
+        },
+        "wd_383": {
+            "name": "wd_383",
+            "object_class": "Equation",
+            "value": "0.0 + wd_382"
+        },
+        "wd_384": {
+            "name": "wd_384",
+            "object_class": "Equation",
+            "value": "0.0 + wd_383"
+        },
+        "wd_385": {
+            "name": "wd_385",
+            "object_class": "Equation",
+            "value": "0.0 + wd_384"
+        },
+        "wd_386": {
+            "name": "wd_386",
+            "object_class": "Equation",
+            "value": "0.0 + wd_385"
+        },
+        "wd_387": {
+            "name": "wd_387",
+            "object_class": "Equation",
+            "value": "0.0 + wd_386"
+        },
+        "wd_388": {
+            "name": "wd_388",
+            "object_class": "Equation",
+            "value": "0.0 + wd_387"
+        },
+        "wd_389": {
+            "name": "wd_389",
+            "object_class": "Equation",
+            "value": "0.0 + wd_388"
+        },
+        "wd_390": {
+            "name": "wd_390",
+            "object_class": "Equation",
+            "value": "0.0 + wd_389"
+        },
+        "wd_391": {
+            "name": "wd_391",
+            "object_class": "Equation",
+            "value": "0.0 + wd_390"
+        },
+        "wd_392": {
+            "name": "wd_392",
+            "object_class": "Equation",
+            "value": "0.0 + wd_391"
+        },
+        "wd_393": {
+            "name": "wd_393",
+            "object_class": "Equation",
+            "value": "0.0 + wd_392"
+        },
+        "wd_394": {
+            "name": "wd_394",
+            "object_class": "Equation",
+            "value": "0.0 + wd_393"
+        },
+        "wd_395": {
+            "name": "wd_395",
+            "object_class": "Equation",
+            "value": "0.0 + wd_394"
+        },
+        "wd_396": {
+            "name": "wd_396",
+            "object_class": "Equation",
+            "value": "0.0 + wd_395"
+        },
+        "wd_397": {
+            "name": "wd_397",
+            "object_class": "Equation",
+            "value": "0.0 + wd_396"
+        },
+        "wd_398": {
+            "name": "wd_398",
+            "object_class": "Equation",
+            "value": "0.0 + wd_397"
+        },
+        "wd_399": {
+            "name": "wd_399",
+            "object_class": "Equation",
+            "value": "0.0 + wd_398"
+        },
+        "wd_400": {
+            "name": "wd_400",
+            "object_class": "Equation",
+            "value": "0.0 + wd_399"
+        },
+        "wd_401": {
+            "name": "wd_401",
+            "object_class": "Equation",
+            "value": "0.0 + wd_400"
+        },
+        "wd_402": {
+            "name": "wd_402",
+            "object_class": "Equation",
+            "value": "0.0 + wd_401"
+        },
+        "wd_403": {
+            "name": "wd_403",
+            "object_class": "Equation",
+            "value": "0.0 + wd_402"
+        },
+        "wd_404": {
+            "name": "wd_404",
+            "object_class": "Equation",
+            "value": "0.0 + wd_403"
+        },
+        "wd_405": {
+            "name": "wd_405",
+            "object_class": "Equation",
+            "value": "0.0 + wd_404"
+        },
+        "wd_406": {
+            "name": "wd_406",
+            "object_class": "Equation",
+            "value": "0.0 + wd_405"
+        },
+        "wd_407": {
+            "name": "wd_407",
+            "object_class": "Equation",
+            "value": "0.0 + wd_406"
+        },
+        "wd_408": {
+            "name": "wd_408",
+            "object_class": "Equation",
+            "value": "0.0 + wd_407"
+        },
+        "wd_409": {
+            "name": "wd_409",
+            "object_class": "Equation",
+            "value": "0.0 + wd_408"
+        },
+        "wd_410": {
+            "name": "wd_410",
+            "object_class": "Equation",
+            "value": "0.0 + wd_409"
+        },
+        "wd_411": {
+            "name": "wd_411",
+            "object_class": "Equation",
+            "value": "0.0 + wd_410"
+        },
+        "wd_412": {
+            "name": "wd_412",
+            "object_class": "Equation",
+            "value": "0.0 + wd_411"
+        },
+        "wd_413": {
+            "name": "wd_413",
+            "object_class": "Equation",
+            "value": "0.0 + wd_412"
+        },
+        "wd_414": {
+            "name": "wd_414",
+            "object_class": "Equation",
+            "value": "0.0 + wd_413"
+        },
+        "wd_415": {
+            "name": "wd_415",
+            "object_class": "Equation",
+            "value": "0.0 + wd_414"
+        },
+        "wd_416": {
+            "name": "wd_416",
+            "object_class": "Equation",
+            "value": "0.0 + wd_415"
+        },
+        "wd_417": {
+            "name": "wd_417",
+            "object_class": "Equation",
+            "value": "0.0 + wd_416"
+        },
+        "wd_418": {
+            "name": "wd_418",
+            "object_class": "Equation",
+            "value": "0.0 + wd_417"
+        },
+        "wd_419": {
+            "name": "wd_419",
+            "object_class": "Equation",
+            "value": "0.0 + wd_418"
+        },
+        "wd_420": {
+            "name": "wd_420",
+            "object_class": "Equation",
+            "value": "0.0 + wd_419"
+        },
+        "wd_421": {
+            "name": "wd_421",
+            "object_class": "Equation",
+            "value": "0.0 + wd_420"
+        },
+        "wd_422": {
+            "name": "wd_422",
+            "object_class": "Equation",
+            "value": "0.0 + wd_421"
+        },
+        "wd_423": {
+            "name": "wd_423",
+            "object_class": "Equation",
+            "value": "0.0 + wd_422"
+        },
+        "wd_424": {
+            "name": "wd_424",
+            "object_class": "Equation",
+            "value": "0.0 + wd_423"
+        },
+        "wd_425": {
+            "name": "wd_425",
+            "object_class": "Equation",
+            "value": "0.0 + wd_424"
+        },
+        "wd_426": {
+            "name": "wd_426",
+            "object_class": "Equation",
+            "value": "0.0 + wd_425"
+        },
+        "wd_427": {
+            "name": "wd_427",
+            "object_class": "Equation",
+            "value": "0.0 + wd_426"
+        },
+        "wd_428": {
+            "name": "wd_428",
+            "object_class": "Equation",
+            "value": "0.0 + wd_427"
+        },
+        "wd_429": {
+            "name": "wd_429",
+            "object_class": "Equation",
+            "value": "0.0 + wd_428"
+        },
+        "wd_430": {
+            "name": "wd_430",
+            "object_class": "Equation",
+            "value": "0.0 + wd_429"
+        },
+        "wd_431": {
+            "name": "wd_431",
+            "object_class": "Equation",
+            "value": "0.0 + wd_430"
+        },
+        "wd_432": {
+            "name": "wd_432",
+            "object_class": "Equation",
+            "value": "0.0 + wd_431"
+        },
+        "wd_433": {
+            "name": "wd_433",
+            "object_class": "Equation",
+            "value": "0.0 + wd_432"
+        },
+        "wd_434": {
+            "name": "wd_434",
+            "object_class": "Equation",
+            "value": "0.0 + wd_433"
+        },
+        "wd_435": {
+            "name": "wd_435",
+            "object_class": "Equation",
+            "value": "0.0 + wd_434"
+        },
+        "wd_436": {
+            "name": "wd_436",
+            "object_class": "Equation",
+            "value": "0.0 + wd_435"
+        },
+        "wd_437": {
+            "name": "wd_437",
+            "object_class": "Equation",
+            "value": "0.0 + wd_436"
+        },
+        "wd_438": {
+            "name": "wd_438",
+            "object_class": "Equation",
+            "value": "0.0 + wd_437"
+        },
+        "wd_439": {
+            "name": "wd_439",
+            "object_class": "Equation",
+            "value": "0.0 + wd_438"
+        },
+        "wd_440": {
+            "name": "wd_440",
+            "object_class": "Equation",
+            "value": "0.0 + wd_439"
+        },
+        "wd_441": {
+            "name": "wd_441",
+            "object_class": "Equation",
+            "value": "0.0 + wd_440"
+        },
+        "wd_442": {
+            "name": "wd_442",
+            "object_class": "Equation",
+            "value": "0.0 + wd_441"
+        },
+        "wd_443": {
+            "name": "wd_443",
+            "object_class": "Equation",
+            "value": "0.0 + wd_442"
+        },
+        "wd_444": {
+            "name": "wd_444",
+            "object_class": "Equation",
+            "value": "0.0 + wd_443"
+        },
+        "wd_445": {
+            "name": "wd_445",
+            "object_class": "Equation",
+            "value": "0.0 + wd_444"
+        },
+        "wd_446": {
+            "name": "wd_446",
+            "object_class": "Equation",
+            "value": "0.0 + wd_445"
+        },
+        "wd_447": {
+            "name": "wd_447",
+            "object_class": "Equation",
+            "value": "0.0 + wd_446"
+        },
+        "wd_448": {
+            "name": "wd_448",
+            "object_class": "Equation",
+            "value": "0.0 + wd_447"
+        },
+        "wd_449": {
+            "name": "wd_449",
+            "object_class": "Equation",
+            "value": "0.0 + wd_448"
+        },
+        "wd_450": {
+            "name": "wd_450",
+            "object_class": "Equation",
+            "value": "0.0 + wd_449"
+        },
+        "wd_451": {
+            "name": "wd_451",
+            "object_class": "Equation",
+            "value": "0.0 + wd_450"
+        },
+        "wd_452": {
+            "name": "wd_452",
+            "object_class": "Equation",
+            "value": "0.0 + wd_451"
+        },
+        "wd_453": {
+            "name": "wd_453",
+            "object_class": "Equation",
+            "value": "0.0 + wd_452"
+        },
+        "wd_454": {
+            "name": "wd_454",
+            "object_class": "Equation",
+            "value": "0.0 + wd_453"
+        },
+        "wd_455": {
+            "name": "wd_455",
+            "object_class": "Equation",
+            "value": "0.0 + wd_454"
+        },
+        "wd_456": {
+            "name": "wd_456",
+            "object_class": "Equation",
+            "value": "0.0 + wd_455"
+        },
+        "wd_457": {
+            "name": "wd_457",
+            "object_class": "Equation",
+            "value": "0.0 + wd_456"
+        },
+        "wd_458": {
+            "name": "wd_458",
+            "object_class": "Equation",
+            "value": "0.0 + wd_457"
+        },
+        "wd_459": {
+            "name": "wd_459",
+            "object_class": "Equation",
+            "value": "0.0 + wd_458"
+        },
+        "wd_460": {
+            "name": "wd_460",
+            "object_class": "Equation",
+            "value": "0.0 + wd_459"
+        },
+        "wd_461": {
+            "name": "wd_461",
+            "object_class": "Equation",
+            "value": "0.0 + wd_460"
+        },
+        "wd_462": {
+            "name": "wd_462",
+            "object_class": "Equation",
+            "value": "0.0 + wd_461"
+        },
+        "wd_463": {
+            "name": "wd_463",
+            "object_class": "Equation",
+            "value": "0.0 + wd_462"
+        },
+        "wd_464": {
+            "name": "wd_464",
+            "object_class": "Equation",
+            "value": "0.0 + wd_463"
+        },
+        "wd_465": {
+            "name": "wd_465",
+            "object_class": "Equation",
+            "value": "0.0 + wd_464"
+        },
+        "wd_466": {
+            "name": "wd_466",
+            "object_class": "Equation",
+            "value": "0.0 + wd_465"
+        },
+        "wd_467": {
+            "name": "wd_467",
+            "object_class": "Equation",
+            "value": "0.0 + wd_466"
+        },
+        "wd_468": {
+            "name": "wd_468",
+            "object_class": "Equation",
+            "value": "0.0 + wd_467"
+        },
+        "wd_469": {
+            "name": "wd_469",
+            "object_class": "Equation",
+            "value": "0.0 + wd_468"
+        },
+        "wd_470": {
+            "name": "wd_470",
+            "object_class": "Equation",
+            "value": "0.0 + wd_469"
+        },
+        "wd_471": {
+            "name": "wd_471",
+            "object_class": "Equation",
+            "value": "0.0 + wd_470"
+        },
+        "wd_472": {
+            "name": "wd_472",
+            "object_class": "Equation",
+            "value": "0.0 + wd_471"
+        },
+        "wd_473": {
+            "name": "wd_473",
+            "object_class": "Equation",
+            "value": "0.0 + wd_472"
+        },
+        "wd_474": {
+            "name": "wd_474",
+            "object_class": "Equation",
+            "value": "0.0 + wd_473"
+        },
+        "wd_475": {
+            "name": "wd_475",
+            "object_class": "Equation",
+            "value": "0.0 + wd_474"
+        },
+        "wd_476": {
+            "name": "wd_476",
+            "object_class": "Equation",
+            "value": "0.0 + wd_475"
+        },
+        "wd_477": {
+            "name": "wd_477",
+            "object_class": "Equation",
+            "value": "0.0 + wd_476"
+        },
+        "wd_478": {
+            "name": "wd_478",
+            "object_class": "Equation",
+            "value": "0.0 + wd_477"
+        },
+        "wd_479": {
+            "name": "wd_479",
+            "object_class": "Equation",
+            "value": "0.0 + wd_478"
+        },
+        "wd_480": {
+            "name": "wd_480",
+            "object_class": "Equation",
+            "value": "0.0 + wd_479"
+        },
+        "wd_481": {
+            "name": "wd_481",
+            "object_class": "Equation",
+            "value": "0.0 + wd_480"
+        },
+        "wd_482": {
+            "name": "wd_482",
+            "object_class": "Equation",
+            "value": "0.0 + wd_481"
+        },
+        "wd_483": {
+            "name": "wd_483",
+            "object_class": "Equation",
+            "value": "0.0 + wd_482"
+        },
+        "wd_484": {
+            "name": "wd_484",
+            "object_class": "Equation",
+            "value": "0.0 + wd_483"
+        },
+        "wd_485": {
+            "name": "wd_485",
+            "object_class": "Equation",
+            "value": "0.0 + wd_484"
+        },
+        "wd_486": {
+            "name": "wd_486",
+            "object_class": "Equation",
+            "value": "0.0 + wd_485"
+        },
+        "wd_487": {
+            "name": "wd_487",
+            "object_class": "Equation",
+            "value": "0.0 + wd_486"
+        },
+        "wd_488": {
+            "name": "wd_488",
+            "object_class": "Equation",
+            "value": "0.0 + wd_487"
+        },
+        "wd_489": {
+            "name": "wd_489",
+            "object_class": "Equation",
+            "value": "0.0 + wd_488"
+        },
+        "wd_490": {
+            "name": "wd_490",
+            "object_class": "Equation",
+            "value": "0.0 + wd_489"
+        },
+        "wd_491": {
+            "name": "wd_491",
+            "object_class": "Equation",
+            "value": "0.0 + wd_490"
+        },
+        "wd_492": {
+            "name": "wd_492",
+            "object_class": "Equation",
+            "value": "0.0 + wd_491"
+        },
+        "wd_493": {
+            "name": "wd_493",
+            "object_class": "Equation",
+            "value": "0.0 + wd_492"
+        },
+        "wd_494": {
+            "name": "wd_494",
+            "object_class": "Equation",
+            "value": "0.0 + wd_493"
+        },
+        "wd_495": {
+            "name": "wd_495",
+            "object_class": "Equation",
+            "value": "0.0 + wd_494"
+        },
+        "wd_496": {
+            "name": "wd_496",
+            "object_class": "Equation",
+            "value": "0.0 + wd_495"
+        },
+        "wd_497": {
+            "name": "wd_497",
+            "object_class": "Equation",
+            "value": "0.0 + wd_496"
+        },
+        "wd_498": {
+            "name": "wd_498",
+            "object_class": "Equation",
+            "value": "0.0 + wd_497"
+        },
+        "wd_499": {
+            "name": "wd_499",
+            "object_class": "Equation",
+            "value": "0.0 + wd_498"
+        },
+        "wd_500": {
+            "name": "wd_500",
+            "object_class": "Equation",
+            "value": "0.0 + wd_499"
+        },
+        "O2write": {
+            "name": "O2write",
+            "object_class": "ModelLinkage",
+            "left_path": "/STATE/PL3_5250_0001/RCHRES_R001/O2",
+            "right_path": "/STATE/PL3_5250_0001/RCHRES_R001/wd_500",
+            "link_type": 5
+        }
+    }
+}
+


### PR DESCRIPTION
Trying to stepwise implement the python3 fixes, but *without pandas3* loaded, to determine where the computations get off.
- utilities.py - this was the first fix applied, and it resulted in failing pytest computations.  The functions that were altered were `transform()`, `dayval()`, `hoursval()`, and `monthval()`.  
   - Manual test of `monthval()` suggests that it works fine, and it is only used in `SNOW`
   - Manual tests of `dayval()` and `hoursval()` have not been performed yet.