### PR TITLE
Cap pandas v2

### DIFF
--- a/.github/workflows/hsp2-pip-install-test.yml
+++ b/.github/workflows/hsp2-pip-install-test.yml
@@ -43,7 +43,7 @@ jobs:
                 pandas-version: ['']
                 include:
                     - python-version: '3.11'
-                      pandas-version: pandas>2.0
+                      pandas-version: pandas>2.0,<3.0
                       coverage: true
                     - python-version: '3.11'
                       pandas-version: pandas>1.5,<2.0

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   # Running HSP2
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
-  - pandas
+  - pandas <3.0
   - numba
   - numpy
   - hdf5

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -12,7 +12,7 @@ dependencies:
   # Running HSP2
   - scipy  # Scipy also installs numpy
   # Pandas installs most scientific Python modules, such as Numpy, etc.
-  - pandas >=2.0
+  - pandas >=2.0,<3.0
   - numba
   - numpy
   - hdf5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "cltoolbox",
     "numba",
     "numpy<2.0",
-    "pandas",
+    "pandas<3.0",
     "tables",
     "pyparsing"
 ]


### PR DESCRIPTION
this is a minimal commit to cap pandas temporarily at v2x until version 3 is better understood in our community of developers, and in the python community in general.

@rburghol let's keep your PR open so we can discuss changes, and work towards comprehensive pandas v3 support.