### PR TITLE
bump minimum supported python version to 3.11 (released 2021)

### DIFF
--- a/.github/workflows/hsp2-pip-install-test.yml
+++ b/.github/workflows/hsp2-pip-install-test.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.11', '3.12', '3.13', '3.14']
                 pandas-version: ['']
                 include:
                     - python-version: '3.11'
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.11', '3.12', '3.13', '3.14']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults  # Speeds solving env, by limiting the number of options
 
 dependencies:
-  - python >=3.10
+  - python >=3.11
 
   # Running HSP2
   - scipy  # Scipy also installs numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
@@ -46,7 +46,7 @@ keywords = [
     "python"
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 slim = ["numba", "pandas"]


### PR DESCRIPTION
We currently support a lot of very old versions of python, especially related to our primary dependencies.
https://scientific-python.org/specs/spec-0000/

python 3.11 is not longer supported by python, but it's still supported by our major dependencies:
numba minimum python version is 3.10, 3.11 preferred
numpy minimum python version is 3.11

dropping support for python <3.10 will let us plan for the future, and start take advantage of tests that run with the 'jit' compiler in 3.14. This will also help us transition to pandas 3.x and numpy 2.x (we currently pin to numpy < 2 but v1 is no longer supported).

@rburghol @PaulDudaRESPEC @aufdenkampe @timcera Any objection to working toward modernizing? Keep in mind that old pypi versions will still work on old pythons.