### PR TITLE
Develop class state (against develop)

### DIFF
--- a/examples/state_specl_ops/demo_equation_cli.py
+++ b/examples/state_specl_ops/demo_equation_cli.py
@@ -18,7 +18,7 @@ hdf5_instance = HDF5(fpath)
 
 
 io_manager = IOManager(hdf5_instance)
-uci_obj = io_manager.read_uci()
+uci_obj = io_manager.read_parameters()
 siminfo = uci_obj.siminfo
 opseq = uci_obj.opseq
 # Note: now that the UCI is read in and hdf5 loaded, you can see things like:

--- a/src/hsp2/hsp2/HYDR.py
+++ b/src/hsp2/hsp2/HYDR.py
@@ -11,16 +11,16 @@ Conversion of no category version of HSPF HRCHHYD.FOR into Python"""
 """
 
 
-from numpy import zeros, any, full, nan, array, int64, arange, asarray
+from numpy import zeros, any, full, nan, array, int64, arange
 from pandas import DataFrame
 from math import sqrt, log10
-from numba import njit, types
+from numba import njit
 from numba.typed import List
 from hsp2.hsp2.utilities import initm, make_numba_dict
 
 # the following imports added by rb to handle dynamic code and special actions
-from hsp2.state.state import hydr_get_ix, hydr_init_ix, hydr_state_vars
-from hsp2.hsp2.om import pre_step_model, step_model, model_domain_dependencies
+from hsp2.state.state import hydr_get_ix, get_state_ix
+from hsp2.hsp2.om import pre_step_model, step_model
 from numba.typed import Dict
 
 
@@ -36,7 +36,7 @@ TOLERANCE = 0.001  # newton method max loops
 MAXLOOPS = 100  # newton method exit tolerance
 
 
-def hydr(io_manager, siminfo, parameters, ts, ftables, state):
+def hydr(siminfo, parameters, ts, ftables, state):
     """find the state of the reach/reservoir at the end of the time interval
     and the outflows during the interval
 
@@ -48,7 +48,9 @@ def hydr(io_manager, siminfo, parameters, ts, ftables, state):
        state is a dictionary that contains all dynamic code dictionaries such as:
        - specactions is a dictionary with all special actions
     """
-
+    # TBD: These operations are all preparatory in nature, and will be replaced by code
+    #      in the RCHRES_handler class, which will set properties on RCHRES_class for fast
+    #      and concide run-time execution and memory management.
     steps = siminfo["steps"]  # number of simulation points
     uunits = siminfo["units"]
     nexits = int(parameters["PARAMETERS"]["NEXITS"])
@@ -140,41 +142,21 @@ def hydr(io_manager, siminfo, parameters, ts, ftables, state):
     #######################################################################################
     # the following section (1 of 3) added to HYDR by rb to handle dynamic code and special actions
     #######################################################################################
-    # state_info is some generic things about the simulation
-    # must be numba safe, so we don't just pass the whole state which is not
-    state_info = Dict.empty(key_type=types.unicode_type, value_type=types.unicode_type)
-    state_info["operation"], state_info["segment"], state_info["activity"] = (
-        state["operation"],
-        state["segment"],
-        state["activity"],
-    )
-    state_info["domain"], state_info["state_step_hydr"], state_info["state_step_om"] = (
-        state["domain"],
-        state["state_step_hydr"],
-        state["state_step_om"],
-    )
-    hsp2_local_py = state["hsp2_local_py"]
+    hsp2_local_py = state.hsp2_local_py
     # It appears necessary to load this here, instead of from main.py, otherwise,
     # _hydr_() does not recognize the function state_step_hydr()?
     if hsp2_local_py != False:
         from hsp2_local_py import state_step_hydr
     else:
-        from hsp2.state.state_fn_defaults import state_step_hydr
-    # initialize the hydr paths in case they don't already reside here
-    hydr_init_ix(state, state["domain"])
-    # must split dicts out of state Dict since numba cannot handle mixed-type nested Dicts
-    state_ix, dict_ix, ts_ix = state["state_ix"], state["dict_ix"], state["ts_ix"]
-    state_paths = state["state_paths"]
-    ep_list = (
-        hydr_state_vars()
-    )  # define all eligibile for state integration in state.py
-    # note: calling dependencies with 4th arg = True grabs only "runnable" types, which can save time
-    #       in long simulations, as iterating through non-runnables like Constants consumes time.
-    model_exec_list = model_domain_dependencies(
-        state, state_info["domain"], ep_list, True
-    )
-    model_exec_list = asarray(model_exec_list, dtype="i8")  # format for use in numba
-    op_tokens = state["op_tokens"]
+        from hsp2.state.state_definitions import state_step_hydr
+    # note: get executable dynamic operation model components
+    # TBD: this will be set as a property on each RCHRES object when we move to a class framework
+    activity_path = state.domain + "/" + 'HYDR'
+    #print("HYDR activity_path", activity_path)
+    activity_id = get_state_ix(state.state_paths, activity_path)
+    model_exec_list = state.op_exec_lists[activity_id]
+    #print("model_exec_list", model_exec_list)
+    #print(state.domain, "HYDR called with", state.domain, len(model_exec_list), "op elements.")
     #######################################################################################
 
     # Do the simulation with _hydr_   (ie run reaches simulation code)
@@ -187,14 +169,9 @@ def hydr(io_manager, siminfo, parameters, ts, ftables, state):
         funct,
         Olabels,
         OVOLlabels,
-        state_info,
-        state_paths,
-        state_ix,
-        dict_ix,
-        ts_ix,
+        state,
         state_step_hydr,
-        op_tokens,
-        model_exec_list,
+        model_exec_list
     )
 
     if "O" in ts:
@@ -206,12 +183,10 @@ def hydr(io_manager, siminfo, parameters, ts, ftables, state):
     parameters["PARAMETERS"]["ROS"] = ui["ROS"]
     for i in range(nexits):
         parameters["PARAMETERS"]["OS" + str(i + 1)] = ui["OS" + str(i + 1)]
-    # copy back (modified) operational element data
-    state["state_ix"], state["dict_ix"], state["ts_ix"] = state_ix, dict_ix, ts_ix
     return errors, ERRMSGS
 
 
-@njit(cache=True)
+#@njit(cache=True)
 def _hydr_(
     ui,
     ts,
@@ -221,17 +196,11 @@ def _hydr_(
     funct,
     Olabels,
     OVOLlabels,
-    state_info,
-    state_paths,
-    state_ix,
-    dict_ix,
-    ts_ix,
+    state,
     state_step_hydr,
-    op_tokens,
-    model_exec_list,
+    model_exec_list
 ):
     errors = zeros(int(ui["errlen"])).astype(int64)
-
     steps = int(ui["steps"])  # number of simulation steps
     delts = ui["delt"] * 60.0  # seconds in simulation interval
     uunits = ui["uunits"]
@@ -368,18 +337,23 @@ def _hydr_(
     # other initial vars
     rovol = 0.0
     volev = 0.0
-    IVOL0 = ts["IVOL"]  # the actual inflow in simulation native units
 
     #######################################################################################
     # the following section (2 of 3) added by rb to HYDR, this one to prepare for dynamic state including special actions
     #######################################################################################
-    hydr_ix = hydr_get_ix(state_ix, state_paths, state_info["domain"])
+    hydr_ix = hydr_get_ix(state, state.domain)
     # these are integer placeholders faster than calling the array look each timestep
+    # TBD: These will be replaced by class properties in HYDR_class 
     o1_ix, o2_ix, o3_ix, ivol_ix = (
         hydr_ix["O1"],
         hydr_ix["O2"],
         hydr_ix["O3"],
         hydr_ix["IVOL"],
+    )
+    ovol1_ix, ovol2_ix, ovol3_ix = (
+        hydr_ix["OVOL1"],
+        hydr_ix["OVOL2"],
+        hydr_ix["OVOL3"],
     )
     ro_ix, rovol_ix, volev_ix, vol_ix = (
         hydr_ix["RO"],
@@ -389,12 +363,16 @@ def _hydr_(
     )
     # handle varying length outdgt
     out_ix = arange(nexits)
+    ovol_ix = arange(nexits)
     if nexits > 0:
         out_ix[0] = o1_ix
+        ovol_ix[0] = ovol1_ix
     if nexits > 1:
         out_ix[1] = o2_ix
+        ovol_ix[1] = ovol2_ix
     if nexits > 2:
         out_ix[2] = o3_ix
+        ovol_ix[2] = ovol3_ix
     #######################################################################################
 
     # HYDR (except where noted)
@@ -408,40 +386,45 @@ def _hydr_(
         #######################################################################################
         # the following section (3 of 3) added by rb to accommodate dynamic code, operations models, and special actions
         #######################################################################################
-        # set state_ix with value of local state variables and/or needed vars
-        # Note: we pass IVOL0, not IVOL here since IVOL has been converted to different units
-        state_ix[ro_ix], state_ix[rovol_ix] = ro, rovol
+        # set state.state_ix with value of local state variables and/or needed vars
+        state.state_ix[ro_ix], state.state_ix[rovol_ix] = ro, rovol
         di = 0
         for oi in range(nexits):
-            state_ix[out_ix[oi]] = outdgt[oi]
-        state_ix[vol_ix], state_ix[ivol_ix] = vol, IVOL0[step]
-        state_ix[volev_ix] = volev
+            # Write OVOL for use in equations/specacts.  Note: this must be improved! too much code...
+            state.state_ix[ovol_ix[oi]] = ovol[oi]
+        
+        state.state_ix[vol_ix], state.state_ix[ivol_ix] = vol, IVOL[step]
+        state.state_ix[volev_ix] = volev
         # - these if statements may be irrelevant if default functions simply return
         #   when no objects are defined.
-        if state_info["state_step_om"] == "enabled":
-            pre_step_model(model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step)
-        if state_info["state_step_hydr"] == "enabled":
+        if state.state_step_om == "enabled":
+            pre_step_model(model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step)
+        
+        if state.state_step_hydr == "enabled":
             state_step_hydr(
-                state_info, state_paths, state_ix, dict_ix, ts_ix, hydr_ix, step
+                state, step
             )
-        if state_info["state_step_om"] == "enabled":
+        
+        if state.state_step_om == "enabled":
             # print("trying to execute state_step_om()")
             # model_exec_list contains the model exec list in dependency order
             # now these are all executed at once, but we need to make them only for domain end points
+            #if step < 2:
+            #    print("Calling step_model with", len(model_exec_list), "out of", len(state.op_tokens), "tokens")
             step_model(
-                model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step
+                model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step
             )  # traditional 'ACTIONS' done in here
-        if (state_info["state_step_hydr"] == "enabled") or (
-            state_info["state_step_om"] == "enabled"
+        if (state.state_step_hydr == "enabled") or (
+            state.state_step_om == "enabled"
         ):
             # Do write-backs for editable STATE variables
             # OUTDGT is writeable
             for oi in range(nexits):
-                outdgt[oi] = state_ix[out_ix[oi]]
+                outdgt[oi] = state.state_ix[out_ix[oi]]
             # IVOL is writeable.
             # Note: we must convert IVOL to the units expected in _hydr_
             # maybe routines should do this, and this is not needed (but pass VFACT in state)
-            IVOL[step] = state_ix[ivol_ix] * VFACT
+            IVOL[step] = state.state_ix[ivol_ix]
         # End dynamic code step()
         #######################################################################################
 
@@ -866,12 +849,3 @@ def expand_HYDR_masslinks(flags, parameters, dat, recs):
         rec["SVOL"] = dat.SVOL
         recs.append(rec)
     return recs
-
-
-def hydr_load_om(state, io_manager, siminfo):
-    for i in hydr_state_vars():
-        state["model_data"][seg_name][i] = {
-            "object_class": "ModelVariable",
-            "name": i,
-            "value": 0.0,
-        }

--- a/src/hsp2/hsp2/RQUAL.py
+++ b/src/hsp2/hsp2/RQUAL.py
@@ -6,14 +6,13 @@ License: LGPL2
 import numpy as np
 from numba import njit, types
 from numba.typed import Dict
-from numpy import full, zeros, asarray
+from numpy import full, zeros
 
 from hsp2.hsp2.RQUAL_Class import RQUAL_Class
 from hsp2.hsp2.utilities import initm, initmd, make_numba_dict
 
 # the following imports added to handle special actions
-from hsp2.state.state import rqual_init_ix, rqual_state_vars
-from hsp2.hsp2.om import model_domain_dependencies
+from hsp2.state.state import get_state_ix
 
 ERRMSGS_oxrx = (
     "OXRX: Warning -- SATDO is less than zero. This usually occurs when water temperature is very high (above ~66 deg. C). This usually indicates an error in input GATMP (or TW, if HTRCH is not being simulated).",
@@ -251,33 +250,10 @@ def rqual(
     #######################################################################################
     # the following section (1 of 3) added to RQUAL by pbd to handle special actions
     #######################################################################################
-    # state_info is some generic things about the simulation
-    # must be numba safe, so we don't just pass the whole state which is not
-    state_info = Dict.empty(key_type=types.unicode_type, value_type=types.unicode_type)
-    state_info["operation"], state_info["segment"], state_info["activity"] = (
-        state["operation"],
-        state["segment"],
-        state["activity"],
-    )
-    state_info["domain"], state_info["state_step_hydr"], state_info["state_step_om"] = (
-        state["domain"],
-        state["state_step_hydr"],
-        state["state_step_om"],
-    )
-    # must split dicts out of state Dict since numba cannot handle mixed-type nested Dicts
-    # initialize the rqual paths in case they don't already reside here
-    rqual_init_ix(state, state["domain"])
-    state_ix, dict_ix, ts_ix = state["state_ix"], state["dict_ix"], state["ts_ix"]
-    state_paths = state["state_paths"]
-    op_tokens = state["op_tokens"]
-    # Aggregate the list of all RQUAL end point dependencies
-    ep_list = (
-        rqual_state_vars()
-    )  # define all eligibile for state integration in state.py
-    model_exec_list = model_domain_dependencies(
-        state, state_info["domain"], ep_list, True
-    )
-    model_exec_list = asarray(model_exec_list, dtype="i8")
+    # Aggregate the list of all SEDTRN end point dependencies
+    activity_path = state.domain + "/" + 'SEDTRN'
+    activity_id = get_state_ix(state.state_paths, activity_path)
+    model_exec_list = state.op_exec_lists[activity_id]
     #######################################################################################
 
     # ---------------------------------------------------------------------
@@ -292,12 +268,7 @@ def rqual(
         ui_plank,
         ui_phcarb,
         ts,
-        state_info,
-        state_paths,
-        state_ix,
-        dict_ix,
-        ts_ix,
-        op_tokens,
+        state,
         model_exec_list,
     )
 
@@ -364,12 +335,7 @@ def _rqual_run(
     ui_plank,
     ui_phcarb,
     ts,
-    state_info,
-    state_paths,
-    state_ix,
-    dict_ix,
-    ts_ix,
-    op_tokens,
+    state,
     model_exec_list,
 ):
     nutrx_errors = zeros((0), dtype=np.int64)
@@ -382,12 +348,7 @@ def _rqual_run(
     # run WQ simulation:
     RQUAL.simulate(
         ts,
-        state_info,
-        state_paths,
-        state_ix,
-        dict_ix,
-        ts_ix,
-        op_tokens,
+        state,
         model_exec_list,
     )
 

--- a/src/hsp2/hsp2/RQUAL_Class.py
+++ b/src/hsp2/hsp2/RQUAL_Class.py
@@ -823,18 +823,13 @@ class RQUAL_Class:
     def simulate(
         self,
         ts,
-        state_info,
-        state_paths,
-        state_ix,
-        dict_ix,
-        ts_ix,
-        op_tokens,
+        state,
         model_exec_list,
     ):
         #######################################################################################
         # the following section (2 of 3) added by pbd to RQUAL, this one to prepare for special actions
         #######################################################################################
-        rqual_ix = rqual_get_ix(state_ix, state_paths, state_info["domain"])
+        rqual_ix = rqual_get_ix(state, state.domain)
         # these are integer placeholders faster than calling the array look each timestep
         dox_ix = rqual_ix["DOX"]
         bod_ix = rqual_ix["BOD"]
@@ -854,40 +849,41 @@ class RQUAL_Class:
             # the following section (3 of 3) added by pbd to accommodate special actions
             #######################################################################################
             # set state_ix with value of local state variables and/or needed vars
-            state_ix[dox_ix] = self.OXRX.dox
-            state_ix[bod_ix] = self.OXRX.bod
-            state_ix[no3_ix] = self.NUTRX.no3
-            state_ix[tam_ix] = self.NUTRX.tam
-            state_ix[no2_ix] = self.NUTRX.no2
-            state_ix[po4_ix] = self.NUTRX.po4
-            state_ix[brtam1_ix] = self.NUTRX.brtam[0]
-            state_ix[brtam2_ix] = self.NUTRX.brtam[1]
-            state_ix[brpo41_ix] = self.NUTRX.brpo4[0]
-            state_ix[brpo42_ix] = self.NUTRX.brpo4[1]
-            state_ix[cforea_ix] = self.OXRX.cforea
-            if state_info["state_step_om"] == "enabled":
+            state.state_ix[dox_ix] = self.OXRX.dox
+            state.state_ix[bod_ix] = self.OXRX.bod
+            state.state_ix[no3_ix] = self.NUTRX.no3
+            state.state_ix[tam_ix] = self.NUTRX.tam
+            state.state_ix[no2_ix] = self.NUTRX.no2
+            state.state_ix[po4_ix] = self.NUTRX.po4
+            state.state_ix[brtam1_ix] = self.NUTRX.brtam[0]
+            state.state_ix[brtam2_ix] = self.NUTRX.brtam[1]
+            state.state_ix[brpo41_ix] = self.NUTRX.brpo4[0]
+            state.state_ix[brpo42_ix] = self.NUTRX.brpo4[1]
+            state.state_ix[cforea_ix] = self.OXRX.cforea
+            if state.state_step_om == "enabled":
                 pre_step_model(
-                    model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step=loop
+                    model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step=loop
                 )
 
             # (todo) Insert code hook for dynamic python modification of state
 
-            if state_info["state_step_om"] == "enabled":
+            if state.state_step_om == "enabled":
+                # (todo) migrate runtime jit code to new state object model
                 step_model(
-                    model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step=loop
+                    model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step=loop
                 )  # traditional 'ACTIONS' done in here
                 # Do write-backs for editable STATE variables
-                self.OXRX.dox = state_ix[dox_ix]
-                self.OXRX.bod = state_ix[bod_ix]
-                self.NUTRX.no3 = state_ix[no3_ix]
-                self.NUTRX.tam = state_ix[tam_ix]
-                self.NUTRX.no2 = state_ix[no2_ix]
-                self.NUTRX.po4 = state_ix[po4_ix]
-                self.NUTRX.brtam[0] = state_ix[brtam1_ix]
-                self.NUTRX.brtam[1] = state_ix[brtam2_ix]
-                self.NUTRX.brpo4[0] = state_ix[brpo41_ix]
-                self.NUTRX.brpo4[1] = state_ix[brpo42_ix]
-                self.OXRX.cforea = state_ix[cforea_ix]
+                self.OXRX.dox = state.state_ix[dox_ix]
+                self.OXRX.bod = state.state_ix[bod_ix]
+                self.NUTRX.no3 = state.state_ix[no3_ix]
+                self.NUTRX.tam = state.state_ix[tam_ix]
+                self.NUTRX.no2 = state.state_ix[no2_ix]
+                self.NUTRX.po4 = state.state_ix[po4_ix]
+                self.NUTRX.brtam[0] = state.state_ix[brtam1_ix]
+                self.NUTRX.brtam[1] = state.state_ix[brtam2_ix]
+                self.NUTRX.brpo4[0] = state.state_ix[brpo41_ix]
+                self.NUTRX.brpo4[1] = state.state_ix[brpo42_ix]
+                self.OXRX.cforea = state.state_ix[cforea_ix]
             #######################################################################################
 
             # -------------------------------------------------------

--- a/src/hsp2/hsp2/SEDMNT.py
+++ b/src/hsp2/hsp2/SEDMNT.py
@@ -59,21 +59,21 @@ def sedmnt(io_manager, siminfo, parameters, ts, state):
     # must be numba safe, so we don't just pass the whole state which is not
     state_info = Dict.empty(key_type=types.unicode_type, value_type=types.unicode_type)
     state_info["operation"], state_info["segment"], state_info["activity"] = (
-        state["operation"],
-        state["segment"],
-        state["activity"],
+        state.operation,
+        state.segment,
+        state.activity,
     )
     state_info["domain"], state_info["state_step_hydr"], state_info["state_step_om"] = (
-        state["domain"],
-        state["state_step_hydr"],
-        state["state_step_om"],
+        state.domain,
+        state.state_step_hydr,
+        state.state_step_om,
     )
     # must split dicts out of state Dict since numba cannot handle mixed-type nested Dicts
     # initialize the sedmnt paths in case they don't already reside here
-    sedmnt_init_ix(state, state["domain"])
-    state_ix, dict_ix, ts_ix = state["state_ix"], state["dict_ix"], state["ts_ix"]
-    state_paths = state["state_paths"]
-    op_tokens = state["op_tokens"]
+    sedmnt_init_ix(state, state.domain)
+    state_ix, dict_ix, ts_ix = state.state_ix, state.dict_ix, state.ts_ix
+    state_paths = state.state_paths
+    op_tokens = state.op_tokens
     # Aggregate the list of all SEDMNT end point dependencies
     ep_list = (
         sedmnt_state_vars()

--- a/src/hsp2/hsp2/SEDTRN.py
+++ b/src/hsp2/hsp2/SEDTRN.py
@@ -10,8 +10,8 @@ from hsp2.hsp2.ADCALC import advect
 from hsp2.hsp2.utilities import make_numba_dict
 
 # the following imports added to handle special actions
-from hsp2.state.state import sedtrn_get_ix, sedtrn_init_ix, sedtrn_state_vars
-from hsp2.hsp2.om import pre_step_model, step_model, model_domain_dependencies
+from hsp2.state.state import sedtrn_get_ix, get_state_ix
+from hsp2.hsp2.om import pre_step_model, step_model
 from numba.typed import Dict
 
 ERRMSGS = (
@@ -25,7 +25,7 @@ ERRMSGS = (
 )  # ERRMSG6
 
 
-def sedtrn(io_manager, siminfo, parameters, ts, state):
+def sedtrn(siminfo, parameters, ts, state):
     """Simulate behavior of inorganic sediment"""
 
     # simlen = siminfo['steps']
@@ -91,19 +91,6 @@ def sedtrn(io_manager, siminfo, parameters, ts, state):
     #######################################################################################
     # the following section (1 of 3) added to SEDTRN by pbd to handle special actions
     #######################################################################################
-    # state_info is some generic things about the simulation
-    # must be numba safe, so we don't just pass the whole state which is not
-    state_info = Dict.empty(key_type=types.unicode_type, value_type=types.unicode_type)
-    state_info["operation"], state_info["segment"], state_info["activity"] = (
-        state["operation"],
-        state["segment"],
-        state["activity"],
-    )
-    state_info["domain"], state_info["state_step_hydr"], state_info["state_step_om"] = (
-        state["domain"],
-        state["state_step_hydr"],
-        state["state_step_om"],
-    )
     # hsp2_local_py = state['hsp2_local_py']
     # # It appears necessary to load this here, instead of from main.py, otherwise,
     # # _hydr_() does not recognize the function state_step_hydr()?
@@ -112,31 +99,17 @@ def sedtrn(io_manager, siminfo, parameters, ts, state):
     # else:
     #     from hsp2.state.state_fn_defaults import state_step_hydr
     # must split dicts out of state Dict since numba cannot handle mixed-type nested Dicts
-    # initialize the sedtrn paths in case they don't already reside here
-    sedtrn_init_ix(state, state["domain"])
-    state_ix, dict_ix, ts_ix = state["state_ix"], state["dict_ix"], state["ts_ix"]
-    state_paths = state["state_paths"]
-    op_tokens = state["op_tokens"]
     # Aggregate the list of all SEDTRN end point dependencies
-    ep_list = (
-        sedtrn_state_vars()
-    )  # define all eligibile for state integration in state.py
-    model_exec_list = model_domain_dependencies(
-        state, state_info["domain"], ep_list, True
-    )
-    model_exec_list = asarray(model_exec_list, dtype="i8")  # format for use in
+    activity_path = state.domain + "/" + 'SEDTRN'
+    activity_id = get_state_ix(state.state_paths, activity_path)
+    model_exec_list = state.op_exec_lists[activity_id]
     #######################################################################################
 
     ############################################################################
     errors = _sedtrn_(
         ui,
         ts,
-        state_info,
-        state_paths,
-        state_ix,
-        dict_ix,
-        ts_ix,
-        op_tokens,
+        state,
         model_exec_list,
     )  # run SEDTRN simulation code
     ############################################################################
@@ -165,12 +138,7 @@ def sedtrn(io_manager, siminfo, parameters, ts, state):
 def _sedtrn_(
     ui,
     ts,
-    state_info,
-    state_paths,
-    state_ix,
-    dict_ix,
-    ts_ix,
-    op_tokens,
+    state,
     model_exec_list,
 ):
     """Simulate behavior of inorganic sediment"""
@@ -403,7 +371,7 @@ def _sedtrn_(
     #######################################################################################
     # the following section (2 of 3) added by pbd to SEDTRN, this one to prepare for special actions
     #######################################################################################
-    sedtrn_ix = sedtrn_get_ix(state_ix, state_paths, state_info["domain"])
+    sedtrn_ix = sedtrn_get_ix(state, state.domain)
     # these are integer placeholders faster than calling the array look each timestep
     rsed4_ix, rsed5_ix, rsed6_ix = (
         sedtrn_ix["RSED4"],
@@ -417,24 +385,25 @@ def _sedtrn_(
         # the following section (3 of 3) added by pbd to accommodate special actions
         #######################################################################################
         # set state_ix with value of local state variables and/or needed vars
-        state_ix[rsed4_ix] = sand_wt_rsed4
-        state_ix[rsed5_ix] = silt_wt_rsed5
-        state_ix[rsed6_ix] = clay_wt_rsed6
-        if state_info["state_step_om"] == "enabled":
+        state.state_ix[rsed4_ix] = sand_wt_rsed4
+        state.state_ix[rsed5_ix] = silt_wt_rsed5
+        state.state_ix[rsed6_ix] = clay_wt_rsed6
+        if state.state_step_om == "enabled":
             pre_step_model(
-                model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step=loop
+                model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step=loop
             )
 
         # (todo) Insert code hook for dynamic python modification of state
 
-        if state_info["state_step_om"] == "enabled":
+        if state.state_step_om == "enabled":
+            # (todo) migrate runtime jit code to new state object model
             step_model(
-                model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step=loop
+                model_exec_list, state.op_tokens, state.state_ix, state.dict_ix, state.ts_ix, step=loop
             )  # traditional 'ACTIONS' done in here
             # Do write-backs for editable STATE variables
-            sand_wt_rsed4 = state_ix[rsed4_ix]
-            silt_wt_rsed5 = state_ix[rsed5_ix]
-            clay_wt_rsed6 = state_ix[rsed6_ix]
+            sand_wt_rsed4 = state.state_ix[rsed4_ix]
+            silt_wt_rsed5 = state.state_ix[rsed5_ix]
+            clay_wt_rsed6 = state.state_ix[rsed6_ix]
         #######################################################################################
 
         # perform any necessary unit conversions

--- a/src/hsp2/hsp2/SPECL.py
+++ b/src/hsp2/hsp2/SPECL.py
@@ -19,6 +19,10 @@ def specl_load_om(om_operations, specactions):
             opname = "SPEC" + "ACTION" + str(ix)
             om_operations["model_data"][opname] = {}
             om_operations["model_data"][opname]["name"] = opname
+            # now, by this point the model domain should have been loaded to include all active segments
+            # so, because HSP* allows SPEC-ACTIONS and other items to exist in the UCI even if they are 
+            # not ACTIVE (i.e. not in the OPN SEQUENCE block), then we must screen out those SPECACTIONS
+            # that operate on an inactive endpoint
             for ik in speca.keys():
                 # print("looking for speca key ", ik)
                 om_operations["model_data"][opname][ik] = speca.to_dict()[ik][

--- a/src/hsp2/hsp2/SPECL.py
+++ b/src/hsp2/hsp2/SPECL.py
@@ -9,33 +9,33 @@ Notes:
 from numba import njit
 
 
-def specl_load_om(state, io_manager, siminfo):
-    if "ACTIONS" in state["specactions"]:
-        dc = state["specactions"]["ACTIONS"]
+def specl_load_om(om_operations, specactions):
+    if "ACTIONS" in specactions:
+        dc = specactions["ACTIONS"]
         for ix in dc.index:
             # add the items to the state['model_data'] dict
             speca = dc[ix : (ix + 1)]
             # need to add a name attribute
             opname = "SPEC" + "ACTION" + str(ix)
-            state["model_data"][opname] = {}
-            state["model_data"][opname]["name"] = opname
+            om_operations["model_data"][opname] = {}
+            om_operations["model_data"][opname]["name"] = opname
             for ik in speca.keys():
                 # print("looking for speca key ", ik)
-                state["model_data"][opname][ik] = speca.to_dict()[ik][
+                om_operations["model_data"][opname][ik] = speca.to_dict()[ik][
                     ix
                 ]  # add subscripts?
                 if ik == "VARI":
                     if len(speca.to_dict()["S1"][ix]) > 0:
-                        state["model_data"][opname][ik] += speca.to_dict()["S1"][ix]
+                        om_operations["model_data"][opname][ik] += speca.to_dict()["S1"][ix]
                     if len(speca.to_dict()["S2"][ix]) > 0:
-                        state["model_data"][opname][ik] += speca.to_dict()["S2"][ix]
-            state["model_data"][opname]["object_class"] = "SpecialAction"
+                        om_operations["model_data"][opname][ik] += speca.to_dict()["S2"][ix]
+            om_operations["model_data"][opname]["object_class"] = "SpecialAction"
             # print("model_data", ix, " = ", state['model_data'][opname])
     return
 
 
-def specl_load_state(state, io_manager, siminfo):
-    specl_load_om(state, io_manager, siminfo)
+def specl_load_state(om_operations, specactions):
+    specl_load_om(om_operations, specactions)
     # others defined below, like:
     # specl_load_uvnames(state, io_manager, siminfo)
     # ...

--- a/src/hsp2/hsp2/main.py
+++ b/src/hsp2/hsp2/main.py
@@ -18,17 +18,9 @@ from hsp2.hsp2.utilities import (
     get_gener_timeseries,
 )
 from hsp2.hsp2.configuration import activities, noop, expand_masslinks
-from hsp2.state.state import (
-    init_state_dicts,
-    state_siminfo_hsp2,
-    state_load_dynamics_hsp2,
-    state_init_hsp2,
-    state_context_hsp2,
-)
+from hsp2.state.state import state_context_hsp2, state_copy
 from hsp2.hsp2.om import (
-    om_init_state,
-    state_om_model_run_prep,
-    state_load_dynamics_om,
+    om_state_hsp2_run_setup,
     state_om_model_run_finish,
 )
 from hsp2.hsp2.SPECL import specl_load_state
@@ -87,23 +79,7 @@ def main(
     # initialize STATE dicts
     #######################################################################################
     # Set up Things in state that will be used in all modular activities like SPECL
-    state = init_state_dicts()
-    state_siminfo_hsp2(parameter_obj, siminfo, io_manager, state)
-    # Add support for dynamic functions to operate on STATE
-    # - Load any dynamic components if present, and store variables on objects
-    state_load_dynamics_hsp2(state, io_manager, siminfo)
-    # Iterate through all segments and add crucial paths to state
-    # before loading dynamic components that may reference them
-    state_init_hsp2(state, opseq, activities)
-    # - finally stash specactions in state, not domain (segment) dependent so do it once
-    state["specactions"] = specactions  # stash the specaction dict in state
-    om_init_state(state)  # set up operational model specific state entries
-    specl_load_state(state, io_manager, siminfo)  # traditional special actions
-    state_load_dynamics_om(
-        state, io_manager, siminfo
-    )  # operational model for custom python
-    # finalize all dynamically loaded components and prepare to run the model
-    state_om_model_run_prep(state, io_manager, siminfo)
+    (state, om_operations, statenb) = om_state_hsp2_run_setup(parameter_obj, io_manager, activities)
     #######################################################################################
 
     # main processing loop
@@ -206,6 +182,7 @@ def main(
                 msg(3, f"{activity}")
                 # Set context for dynamic executables and special actions
                 state_context_hsp2(state, operation, segment, activity)
+                state_copy(state, statenb)
 
                 ui = model[(operation, activity, segment)]  # ui is a dictionary
                 if operation == "PERLND" and activity == "SEDMNT":
@@ -399,11 +376,11 @@ def main(
                 if operation not in ["COPY", "GENER"]:
                     if activity == "HYDR":
                         errors, errmessages = function(
-                            io_manager, siminfo, ui, ts, ftables, state
+                            siminfo, ui, ts, ftables, statenb
                         )
                     elif activity == "SEDTRN" or activity == "SEDMNT":
                         errors, errmessages = function(
-                            io_manager, siminfo, ui, ts, state
+                            siminfo, ui, ts, statenb
                         )
                     elif activity != "RQUAL":
                         errors, errmessages = function(io_manager, siminfo, ui, ts)
@@ -418,7 +395,7 @@ def main(
                             ui_phcarb,
                             ts,
                             monthdata,
-                            state,
+                            statenb,
                         )
                 ###############################################################
 
@@ -522,7 +499,7 @@ def main(
     msglist = msg(1, "Done", final=True)
 
     # Finish operational models
-    state_om_model_run_finish(state, io_manager, siminfo)
+    state_om_model_run_finish(statenb, io_manager, om_operations)
 
     df = DataFrame(msglist, columns=["logfile"])
     io_manager.write_log(df)

--- a/src/hsp2/hsp2/main.py
+++ b/src/hsp2/hsp2/main.py
@@ -67,7 +67,6 @@ def main(
     model = parameter_obj.model
     siminfo = parameter_obj.siminfo
     ftables = parameter_obj.ftables
-    specactions = parameter_obj.specactions
     monthdata = parameter_obj.monthdata
 
     start, stop = siminfo["start"], siminfo["stop"]

--- a/src/hsp2/hsp2/om.py
+++ b/src/hsp2/hsp2/om.py
@@ -5,24 +5,28 @@
 #       defined aove that are called by the object classes
 import json
 import os
-import pandas as pd
-import numpy as np
 import time
-from numpy import zeros
+
+import numpy as np
+from pandas import Series, DataFrame
 from numba import njit  # import the types
-from hsp2.state.state import append_state, get_ix_path
-
-
-def get_exec_order(model_exec_list, var_ix):
-    """
-    Find the integer key of a variable name in state_ix
-    """
-    model_exec_list = dict(enumerate(model_exec_list.flatten(), 1))
-    for exec_order, ix in model_exec_list.items():
-        if var_ix == ix:
-            # we need to add this to the state
-            return exec_order
-    return False
+from numpy import zeros
+from hsp2.hsp2.om_timer import timer_class
+from hsp2.hsp2.SPECL import specl_load_om
+from hsp2.state.state import (
+    append_state,
+    hydr_init_ix,
+    rqual_init_ix,
+    sedmnt_init_ix,
+    sedtrn_init_ix,
+    state_class_numba,
+    state_class,
+    state_siminfo_hsp2,
+    state_init_hsp2,
+    state_copy,
+    state_load_dynamics_hsp2
+)
+from hsp2.state.state_definitions import state_empty
 
 
 def init_op_tokens(op_tokens, tops, eq_ix):
@@ -56,19 +60,20 @@ def model_element_paths(mel, state):
     """
     ixn = 1
     for ix in mel:
-        ip = get_ix_path(state["state_paths"], ix)
-        im = state["model_object_cache"][ip]
+        ip = state.get_ix_path(ix)
+        im = om_operations["model_object_cache"][ip]
         print(ixn, ":", im.name, "->", im.state_path, "=", im.get_state())
         ixn = ixn + 1
     return
 
 
 # Import Code Classes
-from hsp2.hsp2.om_model_object import ModelObject, ModelVariable, pre_step_register
-from hsp2.hsp2.om_sim_timer import SimTimer, step_sim_timer
 from hsp2.hsp2.om_equation import Equation, step_equation
 from hsp2.hsp2.om_model_linkage import ModelLinkage, step_model_link
+from hsp2.hsp2.om_model_object import ModelObject, ModelVariable, pre_step_register
+from hsp2.hsp2.om_sim_timer import SimTimer, step_sim_timer
 from hsp2.hsp2.om_special_action import SpecialAction, step_special_action
+
 # from hsp2.hsp2.om_data_matrix import *
 # from hsp2.hsp2.om_model_broadcast import *
 # from hsp2.hsp2.om_simple_channel import *
@@ -88,7 +93,7 @@ def init_om_dicts():
     return op_tokens, model_object_cache
 
 
-def state_load_om_json(state, io_manager, siminfo):
+def state_load_om_json(state, io_manager, siminfo, om_operations):
     # - model objects defined in file named '[model h5 base].json -- this will populate an array of object definitions that will
     #   be loadable by "model_loader_recursive()"
     # JSON file would be in same path as hdf5
@@ -102,16 +107,14 @@ def state_load_om_json(state, io_manager, siminfo):
         jfile = open(fjson)
         json_data = json.load(jfile)
         # dict.update() combines the arg dict with the base
-        state["model_data"].update(json_data)
-    # merge in the json siminfo data
-    if "siminfo" in state["model_data"].keys():
-        siminfo.update(state["model_data"]["siminfo"])
-    else:
-        state["model_data"]["siminfo"] = siminfo
+        om_operations["model_data"].update(json_data)
+    # merge in the json siminfo data if provided
+    if "siminfo" in om_operations["model_data"].keys():
+        siminfo.update(om_operations["model_data"]["siminfo"])
     return
 
 
-def state_load_om_python(state, io_manager, siminfo):
+def state_load_om_python(state, io_manager, siminfo, om_operations):
     # Look for a [hdf5 file base].py file with specific named functions
     # - function "om_init_model": This function can be defined in the [model h5 base].py file containing things to be done
     #   early in the model loading, like setting up model objects.  This file will already have been loaded by the state module,
@@ -123,34 +126,35 @@ def state_load_om_python(state, io_manager, siminfo):
     (fbase, fext) = os.path.splitext(hdf5_path)
     # see if there is a code module with custom python
     # print("Looking for custom om loader in python code ", (fbase + ".py"))
-    hsp2_local_py = state["hsp2_local_py"]
+    hsp2_local_py = state.state_step_hydr
     # Load a function from code if it exists
     if "om_init_model" in dir(hsp2_local_py):
         hsp2_local_py.om_init_model(
             io_manager,
             siminfo,
-            state["op_tokens"],
-            state["state_paths"],
-            state["state_ix"],
-            state["dict_ix"],
-            state["ts_ix"],
-            state["model_object_cache"],
+            state.op_tokens,
+            state.state_paths,
+            state.state_ix,
+            state.dict_ix,
+            state.ts_ix,
+            om_operations["model_object_cache"],
         )
 
 
-def om_init_state(state):
+def om_init_state():
     # this function will check to see if any of the multiple paths to loading - was state_initialize_om()
     # dynamic operational model objects has been supplied for the model.
     # Grab globals from state for easy handling
     op_tokens, model_object_cache = init_om_dicts()
-    state["op_tokens"], state["model_object_cache"], state["model_exec_list"] = (
-        op_tokens,
-        model_object_cache,
-        [],
-    )
+    om_operations = {}
+    om_operations["op_tokens"] = op_tokens
+    om_operations["model_object_cache"] = model_object_cache
+    om_operations["model_exec_list"] = []
+    om_operations["model_data"] = {}
+    return om_operations
 
 
-def state_load_dynamics_om(state, io_manager, siminfo):
+def state_load_dynamics_om(state, io_manager, siminfo, om_operations):
     # this function will check to see if any of the multiple paths to loading
     # dynamic operational model objects has been supplied for the model.
     # om_init_state(state) must have been called already
@@ -160,112 +164,116 @@ def state_load_dynamics_om(state, io_manager, siminfo):
     #       but if things fail post develop-specact-1 pull requests we may investigate here
     # also, it may be that this should be loaded elsewhere?
     # comment state_load_om_python() to disable dynamic python
-    state_load_om_python(state, io_manager, siminfo)
-    state_load_om_json(state, io_manager, siminfo)
+    state_load_om_python(state, io_manager, siminfo, om_operations)
+    state_load_om_json(state, io_manager, siminfo, om_operations)
     return
 
 
-def state_om_model_root_object(state, siminfo):
+def state_om_model_root_object(state, om_operations, siminfo):
     # Create the base that everything is added to. this object does nothing except host the rest.
-    if "model_root_object" not in state.keys():
+    if "model_root_object" not in om_operations.keys():
         model_root_object = ModelObject(
-            state["model_root_name"], False, {}, state
+            state.model_root_name, False, {}, state, om_operations["model_object_cache"]
         )  # we give this no name so that it does not interfer with child paths like timer, year, etc (i.e. /STATE/year, ...)
-        state["model_root_object"] = model_root_object
+        om_operations["model_root_object"] = model_root_object
         # set up the timer as the first element
-    model_root_object = state["model_root_object"]
-    if "/STATE/timer" not in state["state_paths"].keys():
+    else:
+        model_root_object = om_operations["model_root_object"]
+    #print("model_root_object", timer.split())
+    if "/STATE/timer" not in state.state_paths.keys():
         timer_props = siminfo
         timer_props["state_path"] = "/STATE/timer"
-        timer = SimTimer("timer", model_root_object, timer_props, state)
+        sim_timer = SimTimer("timer", model_root_object, timer_props)
+    #print("timer", timer.split())
     # add base object for the HSP2 domains and other things already added to state so they can be influenced
-    for seg_name, seg_path in state["hsp_segments"].items():
-        if seg_path not in state["model_object_cache"].keys():
+
+
+def om_init_hsp2_segments(state, om_operations):
+    for seg_name, seg_path in state.hsp_segments.items():
+        if seg_path not in om_operations["model_object_cache"].keys():
             # BUG: need to figure out if this is OK, then how do we add attributes to these River Objects
             #      later when adding from json?
             #      Can we simply check the model_object_cache during load step?
             # Create an object shell for this
-            segment = ModelObject(seg_name, model_root_object, {}, state)
-            state["model_object_cache"][segment.state_path] = segment
+            # just get the end of the path, which should be fine since we
+            # don't use model names for anything, but might be more appropriately made as full path
+            segment = ModelObject(seg_name, om_operations["model_root_object"], {})
+            om_operations["model_object_cache"][segment.state_path] = segment
 
 
-def state_om_model_run_prep(state, io_manager, siminfo):
-    # insure model base is set
-    state_om_model_root_object(state, siminfo)
-    # now instantiate and link objects
-    # state['model_data'] has alread been prepopulated from json, .py files, hdf5, etc.
-    model_root_object = state["model_root_object"]
-    model_loader_recursive(state["model_data"], model_root_object, state)
-    # print("Loaded objects & paths: insures all paths are valid, connects models as inputs")
-    # both state['model_object_cache'] and the model_object_cache property of the ModelObject class def
-    # will hold a global repo for this data this may be redundant?  They DO point to the same datset?
-    # since this is a function that accepts state as an argument and these were both set in state_load_dynamics_om
-    # we can assume they are there and functioning
-    model_object_cache = model_root_object.state["model_object_cache"]
-    model_path_loader(model_object_cache)
+def state_om_model_run_prep(opseq, activities, state, om_operations, siminfo):
+    # instantiate and link objects
+    # om_operations['model_data'] has alread been prepopulated from json, .py files, hdf5, etc.
+    model_loader_recursive(
+        om_operations["model_data"], om_operations["model_root_object"], state, om_operations["model_object_cache"]
+    )
+    #print("model_loader_recursive", timer.split())
+    model_path_loader(om_operations["model_object_cache"])
     # len() will be 1 if we only have a simtimer, but > 1 if we have a river being added
-    model_exec_list = state["model_exec_list"]
+    model_exec_list = state.model_exec_list
     # put all objects in token form for fast runtime execution and sort according to dependency order
     # print("Tokenizing models")
     if "ops_data_type" in siminfo.keys():
-        model_root_object.ops_data_type = siminfo[
+        om_operations["model_root_object"].ops_data_type = siminfo[
             "ops_data_type"
         ]  # allow override of dat astructure settings
-    model_root_object.state["op_tokens"] = ModelObject.make_op_tokens(
-        max(model_root_object.state["state_ix"].keys()) + 1
-    )
-    model_tokenizer_recursive(model_root_object, model_object_cache, model_exec_list)
-    op_tokens = model_root_object.state["op_tokens"]
-    # print("op_tokens afer tokenizing", op_tokens)
-    # model_exec_list is the ordered list of component operations
-    # print("model_exec_list(", len(model_exec_list),"items):", model_exec_list)
+    model_tokenizer_recursive(om_operations["model_root_object"], om_operations["model_object_cache"], model_exec_list)
     # This is used to stash the model_exec_list in the dict_ix, this might be slow, need to verify.
     # the resulting set of objects is returned.
-    state["state_step_om"] = "disabled"
-    state["model_object_cache"] = model_object_cache
-    state["model_exec_list"] = np.asarray(model_exec_list, dtype="i8")
-    if model_root_object.ops_data_type == "ndarray":
-        state_keyvals = np.asarray(
-            zeros(max(model_root_object.state["state_ix"].keys()) + 1), dtype="float64"
-        )
-        for ix, val in model_root_object.state["state_ix"].items():
-            state_keyvals[ix] = val
-        state["state_ix"] = state_keyvals
-    else:
-        state["state_ix"] = model_root_object.state["state_ix"]
-    state["op_tokens"] = (
-        op_tokens  # is this superfluous since the root object got op_tokens from state?
-    )
-    if len(op_tokens) > 0:
-        state["state_step_om"] = "enabled"
-
-    # print("op_tokens is type", type(op_tokens))
-    # print("state_ix is type", type(state['state_ix']))
-    # print("state_paths final", state['state_paths'])
-    # print("op_tokens final", op_tokens)
-    # Stash a list of runnables
-    state["runnables"] = ModelObject.runnable_op_list(
-        state["op_tokens"], list(state["state_paths"].values())
-    )
-    # print("Operational model status:", state['state_step_om'])
-    if len(model_exec_list) > 0:
-        # pass
+    state.state_step_om = "disabled"
+    state.model_exec_list = np.asarray(model_exec_list, dtype="int64")
+    if len(state.op_tokens) > 0:
+        state.state_step_om = "enabled"
+    if len(state.op_tokens) > 0:
         print(
             "op_tokens has",
-            len(op_tokens),
-            "elements, with ",
-            len(model_exec_list),
-            "executable elements",
+            len(state.op_tokens),
+            "elements",
         )
-        # print("Exec list:", model_exec_list)
+    # Now make sure that all HSP2 vars that can be affected by state have
+    hsp2_domain_dependencies(state, opseq, activities, om_operations, False)
     return
 
-
-def state_om_model_run_finish(state, io_manager, siminfo):
+def state_om_model_run_finish(state, io_manager, om_operations):
     # write logs and other post-processing steps (if any)
-    finish_model(state, io_manager, siminfo)
+    finish_model(state, io_manager, om_operations)
     return True
 
+# This wraps all the setups for a typical hsp2/om/state simulation into a single function
+# to provide brevity in the main.py as well as simpler testing and prototypin
+def om_state_hsp2_run_setup(parameter_obj, io_manager, activities):
+    timer = timer_class()
+    #######################################################################################
+    # initialize STATE dicts
+    #######################################################################################
+    # Set up Things in state that will be used in all modular activities like SPECL
+    state = state_class(
+        state_empty["state_ix"], state_empty["op_tokens"], state_empty["state_paths"], 
+        state_empty["op_exec_lists"], state_empty["model_exec_list"], state_empty["dict_ix"], 
+        state_empty["ts_ix"], state_empty["hsp_segments"]
+    )
+    om_operations = om_init_state()  # set up operational model specific containers
+    state_siminfo_hsp2(state, parameter_obj, io_manager)
+    state_om_model_root_object(state, om_operations, parameter_obj.siminfo)
+    # Iterate through all segments and add crucial paths to state
+    # before loading dynamic components that may reference them
+    state_init_hsp2(state, parameter_obj.opseq, activities, timer)
+    om_init_hsp2_segments(state, om_operations)
+    # now initialize all state variables for mutable variables
+    hsp2_domain_dependencies(state, parameter_obj.opseq, activities, om_operations, False)
+    # Add support for dynamic functions to operate on STATE
+    # - Load any dynamic components if present, and store variables on objects
+    state_load_dynamics_hsp2(state, io_manager, parameter_obj.siminfo)
+    # - finally stash specactions in state, not domain (segment) dependent so do it once
+    specl_load_om(om_operations, parameter_obj.specactions)  # load traditional special actions
+    state_load_dynamics_om(
+        state, io_manager, parameter_obj.siminfo, om_operations
+    )  # operational model for custom python
+    # finalize all dynamically loaded components and prepare to run the model
+    state_om_model_run_prep(parameter_obj.opseq, activities, state, om_operations, parameter_obj.siminfo)
+    statenb = state_class_numba(0)
+    state_copy(state, statenb)
+    return (state, om_operations, statenb)
 
 # model class reader
 # get model class  to guess object type in this lib
@@ -405,7 +413,7 @@ def model_class_translate(model_props, object_class):
         model_props["object_class"] = "ModelObject"
 
 
-def model_loader_recursive(model_data, container, state):
+def model_loader_recursive(model_data, container, state, model_object_cache):
     k_list = model_data.keys()
     object_names = dict.fromkeys(k_list, 1)
     if type(object_names) is not dict:
@@ -445,7 +453,7 @@ def model_loader_recursive(model_data, container, state):
             if model_props["overwrite"] == True:
                 model_object = False
             else:
-                model_object = state["model_object_cache"][model_object_path]
+                model_object = model_object_cache[model_object_path]
         if model_object == False:
             # try to load this object
             model_object = model_class_loader(
@@ -457,7 +465,7 @@ def model_loader_recursive(model_data, container, state):
         # now for container type objects, go through its properties and handle
         # print("loaded object", model_object, "with container", container)
         if type(model_props) is dict:
-            model_loader_recursive(model_props, model_object, state)
+            model_loader_recursive(model_props, model_object, state, model_object_cache)
 
 
 def model_path_loader(model_object_cache):
@@ -516,7 +524,7 @@ def model_tokenizer_recursive(
                 input_object, model_object_cache, model_exec_list, model_touch_list
             )
         else:
-            if input_path in model_object.state_paths.keys():
+            if input_path in model_object.state.state_paths:
                 # this is a valid state reference without an object
                 # thus, it is likely part of internals that are manually added
                 # which should be fine.  tho perhaps we should have an object for these too.
@@ -532,11 +540,15 @@ def model_tokenizer_recursive(
     # now after tokenizing all inputs this should be OK to tokenize
     model_object.add_op_tokens()
     if model_object.optype in ModelObject.runnables:
-        model_exec_list.append(model_object.ix)
+        model_exec_list = np.append(model_exec_list, model_object.ix)
 
 
 def model_order_recursive(
-    model_object, model_object_cache, model_exec_list, model_touch_list=None
+    model_object,
+    model_object_cache,
+    model_exec_list,
+    model_touch_list=None,
+    debug=False,
 ):
     """
     Given a root model_object, trace the inputs to load things in order
@@ -550,12 +562,28 @@ def model_order_recursive(
             that are sending to that broadcast?
             - Or is it better to let it as it is,
     """
+    if debug:
+        print(
+            "Handling model object:",
+            model_object.name,
+            "with path",
+            model_object.state_path,
+        )
     if model_touch_list is None:
         model_touch_list = []
     if model_object.ix in model_exec_list:
+        if debug:
+            print(model_object.name, "already added to model_exec_list. Returning.")
         return
     if model_object.ix in model_touch_list:
-        # print("Already touched", model_object.name, model_object.ix, model_object.state_path)
+        if debug:
+            print(
+                "Already touched",
+                model_object.name,
+                model_object.ix,
+                model_object.state_path,
+                ". Returning.",
+            )
         return
     # record as having been called, and will ultimately return, to prevent recursions
     model_touch_list.append(model_object.ix)
@@ -581,7 +609,7 @@ def model_order_recursive(
                 input_object, model_object_cache, model_exec_list, model_touch_list
             )
         else:
-            if input_path in model_object.state_paths.keys():
+            if input_path in model_object.state.state_paths:
                 # this is a valid state reference without an object
                 # thus, it is likely part of internals that are manually added
                 # which should be fine.  tho perhaps we should have an object for these too.
@@ -595,32 +623,34 @@ def model_order_recursive(
             )
             return
     # now after loading input dependencies, add this to list
+    if debug:
+        print("Adding", model_object.ix, "to element list")
     model_exec_list.append(model_object.ix)
 
 
-def model_input_dependencies(state, exec_list, only_runnable=False):
+def model_input_dependencies(state, exec_list, model_object_cache, only_runnable=False):
     # TODO: is this redundant to model_domain_dependencies?
     # Cmment in github suggest it is not, and has specific utility
     # for timeseries values? https://github.com/HARPgroup/HSPsquared/issues/60#issuecomment-2231668979
     mello = exec_list
     mtl = []
     mel = []
-    for model_element in state["model_object_cache"].values():
+    for model_element in model_object_cache.values():
         for input_path in model_element.inputs:
-            input_ix = get_state_ix(state["state_ix"], state["state_paths"], input_path)
+            input_ix = get_state_ix(state.state_ix, state.state_paths, input_path)
             if input_ix in exec_list:
                 # do a recursive pull of factors affecting this element
-                model_order_recursive(
-                    model_element, state["model_object_cache"], mel, mtl
-                )
+                model_order_recursive(model_element, model_object_cache, mel, mtl)
                 mello = mello + mel
     if only_runnable == True:
-        mello = ModelObject.runnable_op_list(state["op_tokens"], mello)
-    mello = pd.Series(mello).drop_duplicates().tolist()
+        mello = ModelObject.runnable_op_list(state.op_tokens, mello)
+    mello = Series(mello).drop_duplicates().tolist()
     return mello
 
 
-def model_domain_dependencies(state, domain, ep_list, only_runnable=False):
+def model_domain_dependencies(
+    om_operations, state, domain, ep_list, only_runnable=False, debug=False
+):
     """
     Given an hdf5 style path to a domain, and a list of variable endpoints in that domain,
     Find all model elements that influence the endpoints state
@@ -630,24 +660,62 @@ def model_domain_dependencies(state, domain, ep_list, only_runnable=False):
     for ep in ep_list:
         mel = []
         mtl = []
+        if debug:
+            print("Searching for", (domain + "/" + ep), "in state_paths")
         # if the given element is NOT in model_object_cache, then nothing is acting on it, so we return empty list
-        if (domain + "/" + ep) in state["state_paths"]:
-            if (domain + "/" + ep) in state["model_object_cache"].keys():
-                endpoint = state["model_object_cache"][domain + "/" + ep]
-                model_order_recursive(endpoint, state["model_object_cache"], mel, mtl)
+        if (domain + "/" + ep) in state.state_paths.keys():
+            if (domain + "/" + ep) in om_operations["model_object_cache"].keys():
+                if debug:
+                    print("Found", (domain + "/" + ep), "in om_operations")
+                endpoint = om_operations["model_object_cache"][domain + "/" + ep]
+                model_order_recursive(
+                    endpoint, om_operations["model_object_cache"], mel, mtl
+                )
                 mello = mello + mel
     # TODO: stash the runnable list (mellorun) as a element in dict_ix for cached access during runtime
-    mellorun = ModelObject.runnable_op_list(state["op_tokens"], mello)
+    mellorun = ModelObject.runnable_op_list(state.op_tokens, mello)
     if only_runnable == True:
         mello = mellorun
     return mello
+
+
+def hsp2_domain_dependencies(state, opseq, activities, om_operations, debug=False):
+    # This sets up the state entries for all state compatible HSP2 model variables
+    # print("STATE initializing contexts.")
+    for _, operation, segment, delt in opseq.itertuples():
+        if operation != "GENER" and operation != "COPY":
+            for activity, function in activities[operation].items():
+                # set up named paths for model operations
+                seg_name = operation + "_" + segment
+                seg_path = "/STATE/" + state.model_root_name + "/" + seg_name
+                activity_path = seg_path + "/" + activity
+                activity_id = state.set_state(activity_path, 0.0)
+                ep_list = DataFrame()
+                if debug: 
+                    print("Getting init_ix for", seg_path, activity)
+                if activity == "HYDR":
+                    ep_list = hydr_init_ix(state, seg_path)
+                elif activity == "SEDTRN":
+                    ep_list = sedtrn_init_ix(state, seg_path)
+                elif activity == "SEDMNT":
+                    ep_list = sedmnt_init_ix(state, seg_path)
+                elif activity == "RQUAL":
+                    ep_list = rqual_init_ix(state, seg_path)
+                # Register list of elements to execute if any
+                op_exec_list = model_domain_dependencies(
+                    om_operations, state, seg_path, ep_list, True, debug
+                )
+                op_exec_list = np.asarray(op_exec_list)
+                # register the dependencies for each activity so we can load once here
+                # then just iterate through them at runtime without re-querying
+                state.set_exec_list(activity_id, op_exec_list)
 
 
 def save_object_ts(io_manager, siminfo, op_tokens, ts_ix, ts):
     # Decide on using from utilities.py:
     # - save_timeseries(io_manager, ts, savedict, siminfo, saveall, operation, segment, activity, compress=True)
     # Or, skip the save_timeseries wrapper and call write_ts() directly in io.py:
-    #  write_ts(self, data_frame:pd.DataFrame, save_columns: List[str], category:Category, operation:Union[str,None]=None, segment:Union[str,None]=None, activity:Union[str,None]=None)
+    #  write_ts(self, data_frame:DataFrame, save_columns: List[str], category:Category, operation:Union[str,None]=None, segment:Union[str,None]=None, activity:Union[str,None]=None)
     # see line 317 in utilities.py for use example of write_ts()
     x = 0  # dummy
     return
@@ -665,7 +733,7 @@ def iterate_models(
     return checksum
 
 
-@njit
+@njit(cache=True)
 def pre_step_model(model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step):
     for i in model_exec_list:
         if op_tokens[i][0] == 12:
@@ -676,15 +744,23 @@ def pre_step_model(model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step):
 
 @njit
 def step_model(model_exec_list, op_tokens, state_ix, dict_ix, ts_ix, step):
+    n = 0
     for i in model_exec_list:
+        # skip these - we could optimize performance and return assuming
+        # that the first -1 item is the end of the active components
+        if op_tokens[i][0] == -1: 
+            return
         step_one(op_tokens, op_tokens[i], state_ix, dict_ix, ts_ix, step, 0)
+        n = n + 1
     return
 
 
-def finish_model(state, io_manager, siminfo):
-    # print("Model object cache list", state["model_object_cache"].keys())
-    for i in state["model_exec_list"]:
-        model_object = state["model_object_cache"][get_ix_path(state["state_paths"], i)]
+def finish_model(state, io_manager, om_operations):
+    # print("Model object cache list", om_operations["model_object_cache"].keys())
+    for i in state.model_exec_list:
+        model_object = om_operations["model_object_cache"][
+            state.get_ix_path(i)
+        ]
         if "io_manager" in dir(model_object):
             model_object.io_manager = io_manager
         model_object.finish()
@@ -696,11 +772,11 @@ def step_one(op_tokens, ops, state_ix, dict_ix, ts_ix, step, debug=0):
     # op_tokens is passed in for ops like matrices that have lookups from other
     # locations.  All others rely only on ops
     # todo: decide if all step_[class() functions should set value in state_ix instead of returning value?
-    if debug > 0:
+    if debug:
         print("DEBUG: Operator ID", ops[1], "is op type", ops[0])
         print("DEBUG: ops: ", ops)
     if ops[0] == 1:
-        step_equation(ops, state_ix)
+        step_equation(ops, state_ix, step)
     elif ops[0] == 2:
         # todo: this should be moved into a single function,
         # with the conforming name step_matrix(op_tokens, ops, state_ix, dict_ix)

--- a/src/hsp2/hsp2/om.py
+++ b/src/hsp2/hsp2/om.py
@@ -257,7 +257,7 @@ def om_state_hsp2_run_setup(parameter_obj, io_manager, activities):
     state_om_model_root_object(state, om_operations, parameter_obj.siminfo)
     # Iterate through all segments and add crucial paths to state
     # before loading dynamic components that may reference them
-    state_init_hsp2(state, parameter_obj.opseq, activities, timer)
+    state_init_hsp2(state, parameter_obj.opseq, activities)
     om_init_hsp2_segments(state, om_operations)
     # now initialize all state variables for mutable variables
     hsp2_domain_dependencies(state, parameter_obj.opseq, activities, om_operations, False)

--- a/src/hsp2/hsp2/om.py
+++ b/src/hsp2/hsp2/om.py
@@ -11,7 +11,7 @@ import numpy as np
 from pandas import Series, DataFrame
 from numba import njit  # import the types
 from numpy import zeros
-from hsp2.hsp2.om_timer import timer_class
+from hsp2.state.state_timer import timer_class
 from hsp2.hsp2.SPECL import specl_load_om
 from hsp2.state.state import (
     append_state,

--- a/src/hsp2/hsp2/om_equation.py
+++ b/src/hsp2/hsp2/om_equation.py
@@ -6,26 +6,19 @@ the variable name in question.  Ultimately, everyting becomes either an operator
 in the state_ix Dict for runtime execution.
 """
 
-from hsp2.hsp2.om import is_float_digit
-from hsp2.state.state import set_state, get_state_ix
-from hsp2.hsp2.om_model_object import ModelObject, ModelConstant
 from numba import njit
-from numpy import array, append
+from numpy import append, array
 
-# from hsp2.state.state import set_state, get_state_ix
-# from numba.typed import Dict
-# from hsp2.hsp2.om import get_exec_order, is_float_digit
-# from pandas import Series, DataFrame, concat, HDFStore, set_option, to_numeric
-# from pandas import Timestamp, Timedelta, read_hdf, read_csv
-# from numpy import pad, asarray, zeros, int32
-# from numba import njit, types
+from hsp2.hsp2.om import is_float_digit
+from hsp2.hsp2.om_model_object import ModelConstant, ModelObject
+from hsp2.state.state import get_state_ix, set_state
 
 
 class Equation(ModelObject):
     # the following are supplied by the parent class: name, log_path, attribute_path, state_path, inputs
 
     def __init__(self, name, container=False, model_props={}, state=None):
-        super(Equation, self).__init__(name, container, model_props)
+        super().__init__(name, container, model_props)
         self.equation = self.handle_prop(model_props, "equation")
         self.ps = False
         self.ps_names = []  # Intermediate with constants turned into variable references in state_paths
@@ -137,9 +130,7 @@ class Equation(ModelObject):
             elif is_float_digit(self.var_ops[j]):
                 # must add this to the state array as a constant
                 constant_path = self.state_path + "/_ops/_op" + str(j)
-                s_ix = set_state(
-                    self.state["state_ix"],
-                    self.state["state_paths"],
+                s_ix = self.state.set_state(
                     constant_path,
                     float(self.var_ops[j]),
                 )
@@ -147,9 +138,7 @@ class Equation(ModelObject):
             else:
                 # this is a variable, must find it's data path index
                 var_path = self.find_var_path(self.var_ops[j])
-                s_ix = get_state_ix(
-                    self.state["state_ix"], self.state["state_paths"], var_path
-                )
+                s_ix = self.state.get_state_ix(var_path)
                 if s_ix == False:
                     print(
                         "Error: unknown variable ",
@@ -159,9 +148,7 @@ class Equation(ModelObject):
                         "index",
                         s_ix,
                     )
-                    print(
-                        "searched: ", self.state["state_paths"], self.state["state_ix"]
-                    )
+                    print("searched: ", self.state.state_paths, self.state.state_ix)
                     return
                 else:
                     self.var_ops[j] = s_ix
@@ -178,20 +165,21 @@ class Equation(ModelObject):
         self.ops = self.ops + [self.non_neg, self.min_value_ix] + self.var_ops
 
 
-from pyparsing import (
-    Literal,
-    Word,
-    Group,
-    Forward,
-    alphas,
-    alphanums,
-    Regex,
-    CaselessKeyword,
-    Suppress,
-    delimitedList,
-)
 import math
 import operator
+
+from pyparsing import (
+    CaselessKeyword,
+    Forward,
+    Group,
+    Literal,
+    Regex,
+    Suppress,
+    Word,
+    alphanums,
+    alphas,
+    delimitedList,
+)
 
 exprStack = []
 
@@ -262,7 +250,6 @@ def tokenize_ops(ps):
 
 
 bnf = None
-
 
 def BNF():
     """
@@ -454,7 +441,7 @@ def evaluate_eq_ops(op, val1, val2):
 
 
 @njit
-def step_equation(op_token, state_ix):
+def step_equation(op_token, state_ix, step):
     result = 0
     s = array([0.0])
     s_ix = -1  # pointer to the top of the stack
@@ -462,11 +449,10 @@ def step_equation(op_token, state_ix):
     # handle special equation settings like "non-negative", etc.
     non_neg = op_token[2]
     min_ix = op_token[3]
-    num_ops = op_token[
-        4
-    ]  # this index is equal to the number of ops common to all classes + 1.  See om_model_object for base ops and adjust
+    # this index is equal to the number of ops common to all classes + 1.
+    #  See om_model_object for base ops and adjust
+    num_ops = op_token[4] 
     op_loc = 5  # where do the operators and operands start in op_token
-    # print(num_ops, " operations")
     # is the below faster since it avoids a brief loop and a couple ifs for 2 op equations?
     if num_ops == 1:
         result = evaluate_eq_ops(
@@ -494,7 +480,6 @@ def step_equation(op_token, state_ix):
                 s_ix -= 1
             else:
                 val2 = state_ix[t2]
-            # print(s_ix, op, val1, val2)
             result = evaluate_eq_ops(op, val1, val2)
             s_ix += 1
             if s_ix >= s_len:
@@ -504,5 +489,7 @@ def step_equation(op_token, state_ix):
         result = s[s_ix]
     if (non_neg == 1) and (result < 0):
         result = state_ix[min_ix]
+    #if step < 2:
+    #    print("Eq:", op_token[1], result)
     state_ix[op_token[1]] = result
     return True

--- a/src/hsp2/hsp2/om_model_linkage.py
+++ b/src/hsp2/hsp2/om_model_linkage.py
@@ -4,7 +4,7 @@ It is also used to make an implicit parent child link to insure that an object i
 during a model simulation.
 """
 
-from hsp2.state.state import state_add_ts, get_state_ix
+from hsp2.state.state import state_add_ts
 from hsp2.hsp2.om import *
 from hsp2.hsp2.om_model_object import ModelObject
 from numba import njit
@@ -14,7 +14,7 @@ class ModelLinkage(ModelObject):
     def __init__(self, name, container=False, model_props=None, state=None):
         if model_props is None:
             model_props = {}
-        super(ModelLinkage, self).__init__(name, container, model_props, state=False)
+        super(ModelLinkage, self).__init__(name, container, model_props, state)
         # ModelLinkage copies a values from right to left
         # right_path: is the data source for the link
         # left_path: is the destination of the link
@@ -49,8 +49,8 @@ class ModelLinkage(ModelObject):
             self.left_path = self.state_path
         if self.link_type == 0:
             # if this is a simple input  we remove the object from the model_object_cache, and pass back to parent as an input
-            del self.state["model_object_cache"][self.state_path]
-            del self.state["state_ix"][self.ix]
+            del self.om_operations["model_object_cache"][self.state_path]
+            del self.state.state_ix[self.ix]
             container.add_input(self.name, self.right_path)
         if self.link_type == 6:
             # add an entry into time series dataframe
@@ -96,19 +96,26 @@ class ModelLinkage(ModelObject):
         # self.insure_path(self, self.right_path)
         # the left path, if this is type 4 or 5, is a push, so we must require it
         if (self.link_type == 4) or (self.link_type == 5) or (self.link_type == 6):
-            self.insure_path(self.left_path)
+            #print("ModelLinkage", self.name, "insuring register with path", self.left_path)
             push_pieces = self.left_path.split("/")
             push_name = push_pieces[len(push_pieces) - 1]
-            var_register = self.insure_register(
-                push_name, 0.0, False, self.left_path, False
-            )
-            print(
-                "Created register",
-                var_register.name,
-                "with path",
-                var_register.state_path,
-            )
-            # add already created objects as inputs
+            left_object = self.get_object(self.left_path)
+            if not left_object:
+                # try to fin the parent and create the register since push is allowed
+                left_parent_path = '/'.join(push_pieces[0:len(push_pieces) - 1])
+                left_parent_object = self.get_object(left_parent_path)
+                if not left_parent_object:
+                    raise Exception(
+                        "Cannot find variable path: "
+                        + left_parent_path
+                        + " when trying to push to object "
+                        + push_name
+                    )
+                var_register = self.insure_register(
+                    push_name, 0.0, left_parent_object, self.left_path, False
+                )
+                #print("Created register", var_register.name, "with path", var_register.state_path)
+                # add already created objects as inputs
             var_register.add_object_input(self.name, self, 1)
         # Now, make sure that all time series paths can be found and loaded
         if self.link_type == 3:
@@ -139,18 +146,16 @@ class ModelLinkage(ModelObject):
 
     def write_ts(self, ts=None, ts_cols=None, write_path=None, tindex=None):
         if ts == None:
-            tix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], self.left_path
-            )
+            tix = self.state.get_state_ix(self.left_path)
             # get the ts. Note, we get the ts entry that corresponds to the left_path setting
-            ts = self.state["ts_ix"][tix]
+            ts = self.state.ts_ix[tix]
         if write_path == None:
             if self.left_path != None:
                 write_path = self.left_path
             else:
                 return False
         if tindex == None:
-            tindex = self.state["model_data"]["siminfo"]["tindex"]
+            tindex = self.get_tindex()
         tsdf = self.format_ts(ts, ts_cols, tindex)
         if self.io_manager == False:
             # to do: allow object to specify hdf path name and if so, can open and read/write
@@ -187,9 +192,7 @@ class ModelLinkage(ModelObject):
         # - execution hierarchy
         # print("Linkage/link_type ", self.name, self.link_type,"created with params", self.model_props_parsed)
         if self.link_type in (2, 3):
-            src_ix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], self.right_path
-            )
+            src_ix = self.state.get_state_ix(self.right_path)
             if not (src_ix == False):
                 self.ops = self.ops + [src_ix, self.link_type]
             else:
@@ -197,12 +200,8 @@ class ModelLinkage(ModelObject):
             # print(self.name,"tokenize() result", self.ops)
         if (self.link_type == 4) or (self.link_type == 5) or (self.link_type == 6):
             # we push to the remote path in this one
-            left_ix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], self.left_path
-            )
-            right_ix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], self.right_path
-            )
+            left_ix = self.state.get_state_ix(self.left_path)
+            right_ix = self.state.get_state_ix(self.right_path)
             if (left_ix != False) and (right_ix != False):
                 self.ops = self.ops + [left_ix, self.link_type, right_ix]
             else:
@@ -226,11 +225,8 @@ class ModelLinkage(ModelObject):
 
 
 # Function for use during model simulations of tokenized objects
-@njit
+@njit(cache=True)
 def step_model_link(op_token, state_ix, ts_ix, step):
-    # if step == 2:
-    #    print("step_model_link() called at step 2 with op_token=", op_token)
-    # print("step_model_link() called at step 2 with op_token=", op_token)
     if op_token[3] == 1:
         return True
     elif op_token[3] == 2:
@@ -250,15 +246,6 @@ def step_model_link(op_token, state_ix, ts_ix, step):
         return True
     elif op_token[3] == 6:
         # set value in a timerseries
-        if step < 10:
-            print(
-                "Writing ",
-                state_ix[op_token[4]],
-                "from ix=",
-                op_token[4],
-                "to",
-                op_token[2],
-            )
         ts_ix[op_token[2]][step] = state_ix[op_token[4]]
         return True
 

--- a/src/hsp2/hsp2/om_model_object.py
+++ b/src/hsp2/hsp2/om_model_object.py
@@ -4,12 +4,13 @@ It handles all Dict management functions, but provides for no runtime execution 
 All runtime exec is done by child classes.
 """
 
-from hsp2.state.state import set_state, get_state_ix
-from numba.typed import Dict
-from hsp2.hsp2.om import get_exec_order, is_float_digit
-from pandas import HDFStore
-from numpy import pad, asarray, zeros, int32
 from numba import njit, types
+from numba.typed import Dict
+from numpy import asarray, int64, pad, zeros
+from pandas import HDFStore
+
+from hsp2.hsp2.om import is_float_digit
+from hsp2.state.state import nkey_exists
 
 
 class ModelObject:
@@ -32,27 +33,44 @@ class ModelObject:
     ]  # runnable components important for optimization
     ops_data_type = "ndarray"  # options are ndarray or Dict - Dict appears slower, but unsure of the cause, so keep as option.
 
-    def __init__(self, name, container=False, model_props=None, state=None):
+    def __init__(
+        self,
+        name,
+        container=False,
+        model_props=None,
+        state=None,
+        model_object_cache=None,
+    ):
         self.name = name
+        self.container = container  # will be a link to another object
+        if state is None:
+            # we must verify that we have a properly formatted state Dictionary, or that our parent does.
+            if self.container == False:
+                raise Exception(
+                    "Error: State object must be passed to root object. ",
+                    +name + " cannot be created.  See state::init_state_dicts()",
+                )
+            else:
+                state = self.container.state
+        if model_object_cache is None:
+            # we must verify that we have a properly formatted state Dictionary, or that our parent does.
+            if self.container == False:
+                raise Exception(
+                    "Error: model_object_cache object must be available on to root object. "
+                    + name
+                    + " cannot be created.  See state::init_state_dicts()"
+                )
+            else:
+                model_object_cache = self.container.model_object_cache
+        self.state = state  # make a copy here. is this efficient?
+        self.model_object_cache = (
+            model_object_cache  # make a copy here. is this efficient?
+        )
         self.handle_deprecated_args(name, container, model_props, state)
         # END - handle deprecated
         if model_props is None:
             model_props = {}
-        self.container = container  # will be a link to another object
         self.state_path = self.handle_prop(model_props, "state_path", False, False)
-        if type(state) != dict:
-            # we must verify that we have a properly formatted state Dictionary, or that our parent does.
-            if self.container == False:
-                raise Exception(
-                    "Error: State dictionary must be passed to root object. ",
-                    type(state),
-                    "passed instead."
-                    + name
-                    + " cannot be created.  See state::init_state_dicts()",
-                )
-            else:
-                state = self.container.state
-        self.state = state  # make a copy here. is this efficient?
         # Local properties
         self.model_props_parsed = {}  # a place to stash parse record for debugging
         self.log_path = ""  # Ex: "/RESULTS/RCHRES_001/SPECL"
@@ -109,7 +127,7 @@ class ModelObject:
     @staticmethod
     def make_op_tokens(num_ops=5000):
         if ModelObject.ops_data_type == "ndarray":
-            op_tokens = int32(
+            op_tokens = int64(
                 zeros((num_ops, 64))
             )  # was Dict.empty(key_type=types.int64, value_type=types.i8[:])
         else:
@@ -123,6 +141,7 @@ class ModelObject:
         run_ops = {}
         for ops in op_tokens:
             # the base class defines the type of objects that are runnable (i.e. have a step() method)
+            #print("Handling ops", ops)
             if ops[0] in ModelObject.runnables:
                 run_ops[ops[1]] = ops
                 if debug == True:
@@ -191,6 +210,8 @@ class ModelObject:
                 + self.name
                 + " and strict = True.  Object creation halted. Path to object with error is "
                 + self.state_path
+                + "This objects inputs are:",
+                self.inputs,
             )
         if (prop_val == None) and not (default_value == None):
             prop_val = default_value
@@ -207,19 +228,11 @@ class ModelObject:
         return True
 
     def set_state(self, set_value):
-        var_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
+        var_ix = self.state.set_state(
             self.state_path,
             set_value,
         )
         return var_ix
-
-    def load_state_dicts(self, op_tokens, state_paths, state_ix, dict_ix):
-        self.state["op_tokens"] = op_tokens
-        self.state["state_paths"] = state_paths
-        self.state["state_ix"] = state_ix
-        self.state["dict_ix"] = dict_ix
 
     def save_object_hdf(self, hdfname, overwrite=False):
         # save the object in the full hdf5 path
@@ -232,6 +245,7 @@ class ModelObject:
         # print("calling make_paths from", self.name, "with base path", base_path)
         if base_path == False:  # we are NOT forcing paths
             if not (self.container == False):
+                # print("Using container path as base:", self.container.state_path + "/" + str(self.name))
                 self.state_path = self.container.state_path + "/" + str(self.name)
                 self.attribute_path = (
                     self.container.attribute_path + "/" + str(self.name)
@@ -250,55 +264,58 @@ class ModelObject:
 
     def get_state(self, var_name=False):
         if var_name == False:
-            return self.state["state_ix"][self.ix]
+            return self.state.state_ix[self.ix]
         else:
             var_path = self.find_var_path(var_name)
-            var_ix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], var_path
-            )
+            # print("Looking for state ix of:", var_path)
+            var_ix = self.state.get_state_ix(var_path)
         if var_ix == False:
             return False
-        return self.state["state_ix"][var_ix]
+        return self.state.state_ix[var_ix]
 
-    def get_exec_order(self, var_name=False):
-        if var_name == False:
-            var_ix = self.ix
-        else:
-            var_path = self.find_var_path(var_name)
-            var_ix = get_state_ix(
-                self.state["state_ix"], self.state["state_paths"], var_path
-            )
-        exec_order = get_exec_order(self.state["model_exec_list"], var_ix)
-        return exec_order
+    def get_tindex(self):
+        timer = self.get_object("timer")
+        tindex = self.state.dict_ix[timer.ix]
+        return tindex
 
     def get_object(self, var_name=False):
         if var_name == False:
-            return self.state["model_object_cache"][self.state_path]
+            return self.model_object_cache[self.state_path]
         else:
             var_path = self.find_var_path(var_name)
-            return self.state["model_object_cache"][var_path]
+            if var_path in self.model_object_cache:
+                return self.model_object_cache[var_path]
+            else:
+                return False
 
     def find_var_path(self, var_name, local_only=False):
         # check local inputs for name
+        if var_name is None:
+            print("NULL var searched from", self.name, "child of", self.container.name)
         if type(var_name) == str:
             # print("Expanding aliases for", var_name)
             var_name = self.handle_path_aliases(var_name)  # sub out any wildcards
         # print(self.name, "called", "find_var_path(self, ", var_name, ", local_only = False)")
         if var_name in self.inputs.keys():
             return self.inputs[var_name]
+        # check for state vars in my path + var_name
+        if nkey_exists(self.state.state_paths, self.state_path + "/" + var_name):
+            return self.state_path + "/" + var_name
         if local_only:
+            #print("Cannot find var", var_name, "in local scope", self.name)
             return False  # we are limiting the scope, so just return
         # check parent for name
         if not (self.container == False):
+            #print("Searching for var", var_name, "in container scope", self.container.name, self.container.state_path)
             return self.container.find_var_path(var_name)
         # check for root state vars STATE + var_name
-        if ("/STATE/" + var_name) in self.state["state_paths"].keys():
-            # return self.state['state_paths'][("/STATE/" + var_name)]
+        if ("/STATE/" + var_name) in self.state.state_paths:
             return "/STATE/" + var_name
         # check for full paths
-        if var_name in self.state["state_paths"].keys():
+        if nkey_exists(self.state.state_paths, var_name):
             # return self.state['state_paths'][var_name]
             return var_name
+        #print("Cannot find var in global scope", self.state_path, "var", var_name)
         return False
 
     def constant_or_path(self, keyname, keyval, trust=False):
@@ -318,14 +335,10 @@ class ModelObject:
         # print("register_path called for", self.name, "with state_path", self.state_path)
         if self.state_path == "" or self.state_path == False:
             self.make_paths()
-        self.ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            self.state_path,
-            self.default_value,
-        )
+        self.ix = self.state.set_state(self.state_path, self.default_value)
         # store object in model_object_cache - always, if we have reached this point we need to overwrite
-        self.state["model_object_cache"][self.state_path] = self
+        # print("Adding ", self.name, "with state_path", self.state_path, "to model_object_cache")
+        self.model_object_cache[self.state_path] = self
         # this should check to see if this object has a parent, and if so, register the name on the parent
         # default is as a child object.
         if not (self.container == False):
@@ -350,10 +363,10 @@ class ModelObject:
         #       BUT this only works if both var_name and var_path are month
         #       so add_input('month', 'month', 1, True) works.
         found_path = self.find_var_path(var_path)
-        # print("Searched", var_name, "with path", var_path,"found", found_path)
-        var_ix = get_state_ix(
-            self.state["state_ix"], self.state["state_paths"], found_path
-        )
+        if found_path == False:
+            var_ix = False
+        else:
+            var_ix = self.state.get_state_ix(found_path)
         if var_ix == False:
             if trust == False:
                 raise Exception(
@@ -365,6 +378,10 @@ class ModelObject:
                     + var_name
                     + " ... process terminated. Path to object with error is "
                     + self.state_path
+                    + "This objects inputs are:",
+                    self.inputs,
+                    "State paths=",
+                    self.state.state_paths,
                 )
             var_ix = self.insure_path(var_path)
         else:
@@ -408,15 +425,13 @@ class ModelObject:
         # if this path can be found in the hdf5 make sure that it is registered in state
         # and that it has needed object class to render it at runtime (some are automatic)
         # RIGHT NOW THIS DOES NOTHING TO CHECK IF THE VAR EXISTS THIS MUST BE FIXED
-        var_ix = set_state(
-            self.state["state_ix"], self.state["state_paths"], var_path, 0.0
-        )
+        var_ix = self.state.set_state(var_path, 0.0)
         return var_ix
 
     def get_dict_state(self, ix=-1):
         if ix >= 0:
-            return self.state["dict_ix"][ix]
-        return self.state["dict_ix"][self.ix]
+            return self.state.dict_ix[ix]
+        return self.state.dict_ix[self.ix]
 
     def find_paths(self):
         # Note: every single piece of data used by objects, even constants, are resolved to a PATH in the hdf5
@@ -446,7 +461,7 @@ class ModelObject:
         if register_path == False:
             register_path = register_container.find_var_path(var_name, True)
         if (register_path == False) or (
-            register_path not in self.state["model_object_cache"].keys()
+            register_path not in self.model_object_cache.keys()
         ):
             # create a register as a placeholder for the data at the hub path
             # in case there are no senders, or in the case of a timeseries logger, we need to register it so that its path can be set to hold data
@@ -466,7 +481,7 @@ class ModelObject:
                     var_name, register_container, reg_props, self.state
                 )
         else:
-            var_register = self.state["model_object_cache"][register_path]
+            var_register = self.model_object_cache[register_path]
         return var_register
 
     def tokenize(self):
@@ -495,18 +510,20 @@ class ModelObject:
                 + self.state_path
                 + "). "
             )
-        self.state["op_tokens"][self.ix] = self.format_ops()
+        self.state.set_token(self.ix, self.format_ops())
 
     def step(self, step):
         # this tests the model for a single timestep.
         # this is not the method that is used for high-speed runs, but can theoretically be used for
         # easier to understand demonstrations
+        # this has not been tested since changes to the state from array to object
         step_one(
-            self.state["op_tokens"],
-            self.state["op_tokens"][self.ix],
-            self.state["state_ix"],
-            self.state["dict_ix"],
-            self.state["ts_ix"],
+            self.state.op_tokens,
+            self.state.op_tokens[self.ix],
+            self.state.state_ix,
+            self.state.dict_ix,
+            self.state.state_ix,
+            self.state.ts_ix,
             step,
         )
         # step_model({self.state['op_tokens'][self.ix]}, self.state['state_ix'], self.state['dict_ix'], self.state['ts_ix'], step)
@@ -517,14 +534,10 @@ class ModelObject:
         return True
 
 
-"""
-The class ModelVariable is a base cass for storing numerical values.  Used for UVQUAN and misc numerical constants...
-"""
-
-
 class ModelVariable(ModelObject):
+    #:The class ModelVariable is a base cass for storing numerical values.  Used for UVQUAN and misc numerical constants...
     def __init__(self, name, container=False, model_props=None, state=None):
-        super(ModelVariable, self).__init__(name, container, model_props, state)
+        super().__init__(name, container, model_props, state)
         # print("ModelVariable named", name, "with path", self.state_path,"beginning")
         value = self.handle_prop(model_props, "value")
         self.default_value = float(value)
@@ -540,28 +553,20 @@ class ModelVariable(ModelObject):
         return req_props
 
 
-"""
-The class ModelConstant is for storing non-changing values.
-"""
-
-
 class ModelConstant(ModelVariable):
+    #: The class ModelConstant is for storing non-changing values.
     def __init__(self, name, container=False, model_props=None, state=None):
-        super(ModelConstant, self).__init__(name, container, model_props, state)
+        super().__init__(name, container, model_props, state)
         self.optype = 16  # 0 - shell object, 1 - equation, 2 - datamatrix, 3 - input, 4 - broadcastChannel, 5 - SimTimer, 6 - Conditional, 7 - ModelVariable (numeric)
         # print("ModelVariable named",self.name, "with path", self.state_path,"and ix", self.ix, "value", value)
 
 
-"""
-The class ModelRegister is for storing push values.
-Behavior is to zero each timestep.  This could be amended later.
-Maybe combined with stack behavior?  Or accumulator?
-"""
-
-
 class ModelRegister(ModelVariable):
+    #: The class ModelRegister is for storing push values.
+    #: Behavior is to zero each timestep.  This could be amended later.
+    #: Maybe combined with stack behavior?  Or accumulator?
     def __init__(self, name, container=None, model_props=False, state=False):
-        super(ModelRegister, self).__init__(name, container, model_props, state)
+        super().__init__(name, container, model_props, state)
         self.optype = 12  #
         # self.state['state_ix'][self.ix] = self.default_value
 

--- a/src/hsp2/hsp2/om_sim_timer.py
+++ b/src/hsp2/hsp2/om_sim_timer.py
@@ -4,20 +4,19 @@ It is also used to make an implicit parent child link to insure that an object i
 during a model simulation.
 """
 
-from hsp2.state.state import set_state
 from hsp2.hsp2.om import ModelObject
 from hsp2.hsp2.om_model_object import ModelObject
+from hsp2.state.state import set_numba_value
 from pandas import DataFrame
 from numba import njit
 from numpy import int64
-
 
 class SimTimer(ModelObject):
     def __init__(self, name, container, model_props=None, state=None):
         if model_props is None:
             model_props = {}
         # Note: hsp2 siminfo will match model_props here
-        super(SimTimer, self).__init__(name, container, model_props)
+        super(SimTimer, self).__init__(name, container, model_props, state)
         self.state_path = "/STATE/timer"
         self.time_array = self.dti_to_time_array(
             model_props
@@ -28,80 +27,23 @@ class SimTimer(ModelObject):
 
     def register_components(self):
         # initialize the path variable if not already set
-        self.ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
+        self.ix = self.state.set_state(
             self.state_path,
-            float(self.time_array[0][0]),
+            float(self.time_array[0][0])
         )
         # now register all other paths.
         # register "year", "month" "day", ...
-        year_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/year",
-            float(self.time_array[0][1]),
-        )
-        month_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/month",
-            float(self.time_array[0][2]),
-        )
-        day_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/day",
-            float(self.time_array[0][3]),
-        )
-        hr_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/hour",
-            float(self.time_array[0][4]),
-        )
-        min_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/minute",
-            float(self.time_array[0][5]),
-        )
-        sec_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/second",
-            float(self.time_array[0][6]),
-        )
-        wd_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/weekday",
-            float(self.time_array[0][7]),
-        )
-        dt_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/dt",
-            float(self.time_array[0][8]),
-        )
-        jd_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/jday",
-            float(self.time_array[0][9]),
-        )
-        md_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/modays",
-            float(self.time_array[0][10]),
-        )
-        dts_ix = set_state(
-            self.state["state_ix"],
-            self.state["state_paths"],
-            "/STATE/dts",
-            float(self.time_array[0][8] * 60.0),
-        )
+        year_ix = self.state.set_state("/STATE/year", float(self.time_array[0][1]) )
+        month_ix = self.state.set_state("/STATE/month", float(self.time_array[0][2]))
+        day_ix = self.state.set_state( "/STATE/day", float(self.time_array[0][3]))
+        hr_ix = self.state.set_state( "/STATE/hour", float(self.time_array[0][4]))
+        min_ix = self.state.set_state( "/STATE/minute", float(self.time_array[0][5]))
+        sec_ix = self.state.set_state( "/STATE/second",  float(self.time_array[0][6]))
+        wd_ix = self.state.set_state( "/STATE/weekday", float(self.time_array[0][7]))
+        dt_ix = self.state.set_state( "/STATE/dt", float(self.time_array[0][8]))
+        jd_ix = self.state.set_state( "/STATE/jday", float(self.time_array[0][9]))
+        md_ix = self.state.set_state( "/STATE/modays", float(self.time_array[0][10]))
+        dts_ix = self.state.set_state( "/STATE/dts", float(self.time_array[0][8] * 60.0))
         self.date_path_ix = [
             year_ix,
             month_ix,
@@ -115,7 +57,7 @@ class SimTimer(ModelObject):
             md_ix,
             dts_ix,
         ]
-        self.state["dict_ix"][self.ix] = self.time_array
+        self.state.dict_ix = set_numba_value(self.state.dict_ix, self.ix, self.time_array)
 
         return self.ix
 
@@ -124,12 +66,12 @@ class SimTimer(ModelObject):
         # returns an array of data pointers
         super().tokenize()  # resets ops to common base
         self.ops = self.ops + self.date_path_ix  # adds timer specific items
-
+    
     def add_op_tokens(self):
         # this puts the tokens into the global simulation queue
         # can be customized by subclasses to add multiple lines if needed.
         super().add_op_tokens()
-        self.state["dict_ix"][self.ix] = self.time_array
+        self.state.dict_ix = set_numba_value(self.state.dict_ix, self.ix, self.time_array)
 
     def dti_to_time_array(self, siminfo):
         dateindex = siminfo["tindex"]
@@ -175,3 +117,4 @@ def step_sim_timer(op_token, state_ix, dict_ix, ts_ix, step):
     state_ix[op_token[11]] = dict_ix[op_token[1]][step][10]  # modays
     state_ix[op_token[12]] = dict_ix[op_token[1]][step][11]  # dts
     return
+

--- a/src/hsp2/hsp2/om_special_action.py
+++ b/src/hsp2/hsp2/om_special_action.py
@@ -159,7 +159,8 @@ class SpecialAction(ModelObject):
 
     def find_paths(self):
         # this makes sure that the source prop (and destination prop) exists in the model.
-        # NOTE: since the spec-action modifies the same quantity that is it's input, it does *not* set it as a proper "input" since that would create a circular dependency
+        # NOTE: since the spec-action modifies the same quantity that is it's input, 
+        # it does *not* set it as a proper "input" since that would create a circular dependency
         domain_path = (
             self.container.state_path
             + "/"

--- a/src/hsp2/hsp2/om_special_action.py
+++ b/src/hsp2/hsp2/om_special_action.py
@@ -78,7 +78,7 @@ class SpecialAction(ModelObject):
         if prop_name == "when":
             # when to perform this?  timestamp or time-step index
             prop_val = -1  # prevent a 0 indexed value from triggering return, default means execute every step
-            si = self.model_object_cache[self.find_var_path("timer")]
+            si = self.get_object("timer")
             if len(model_props["YR"]) > 0:
                 # translate date to equivalent model step
                 datestring = (

--- a/src/hsp2/hsp2/om_special_action.py
+++ b/src/hsp2/hsp2/om_special_action.py
@@ -78,7 +78,7 @@ class SpecialAction(ModelObject):
         if prop_name == "when":
             # when to perform this?  timestamp or time-step index
             prop_val = -1  # prevent a 0 indexed value from triggering return, default means execute every step
-            si = self.state["model_object_cache"][self.find_var_path("timer")]
+            si = self.model_object_cache[self.find_var_path("timer")]
             if len(model_props["YR"]) > 0:
                 # translate date to equivalent model step
                 datestring = (
@@ -168,7 +168,7 @@ class SpecialAction(ModelObject):
             + self.op_type[0]
             + str(self.range1).zfill(3)
         )
-        domain = self.state["model_object_cache"][domain_path]
+        domain = self.model_object_cache[domain_path]
         var_register = self.insure_register(self.vari, 0.0, domain, False, False)
         # print("Created register", var_register.name, "with path", var_register.state_path)
         # add already created objects as inputs

--- a/src/hsp2/hsp2tools/HDF5.py
+++ b/src/hsp2/hsp2tools/HDF5.py
@@ -16,7 +16,7 @@ class HDF5:
 
     def __init__(self, file_name: str) -> None:
         self.file_name = file_name
-        self.aliases = hsp2_hspf_aliases()
+        self.aliases = self._read_aliases_csv()
         self.data = {}
         self.lock = Lock()
 
@@ -60,6 +60,13 @@ class HDF5:
     def _read_pqual_mapping(self) -> Dict[str, str]:
         return self._read_nqual_mapping(R"PERLND/PQUAL/PQUAL", "QUALID", 10)
 
+    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
+        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
+        df = pd.read_csv(datapath)
+        df = df.set_index(["operation", "activity", "hspf_name"])
+        df_dict = df["hsp2_name"].to_dict()
+        return df_dict
+
     def get_time_series(
         self, operation: str, id: str, constituent: str, activity: str
     ) -> Union[pd.Series, None]:
@@ -93,7 +100,7 @@ class HDF5:
             if constituent_prefix + constituent in df.columns:
                 return df[constituent_prefix + constituent]
             else:
-                constituent_alias = self.aliases.get_alias((operation, activity, constituent))
+                constituent_alias = self.aliases[(operation, activity, constituent)]
                 return df[constituent_prefix + constituent_alias]
         except KeyError:
             return None
@@ -109,24 +116,3 @@ class HDF5:
                 return df
         except KeyError:
             return pd.DataFrame()
-
-
-
-class hsp2_hspf_aliases:
-    REQUIRES_MAPPING = ["GQUAL", "CONS", "IQUAL", "PQUAL"]
-
-    def __init__(self) -> None:
-        self.aliases = self._read_aliases_csv()
-    
-    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
-        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
-        df = pd.read_csv(datapath)
-        df = df.set_index(["operation", "activity", "hspf_name"])
-        df_dict = df["hsp2_name"].to_dict()
-        return df_dict
-    
-    def get_alias(self, params):
-       if params in self.aliases
-           return self.aliases[params]
-       else:
-           return False

--- a/src/hsp2/hsp2tools/HDF5.py
+++ b/src/hsp2/hsp2tools/HDF5.py
@@ -16,7 +16,7 @@ class HDF5:
 
     def __init__(self, file_name: str) -> None:
         self.file_name = file_name
-        self.aliases = self._read_aliases_csv()
+        self.aliases = hsp2_hspf_aliases()
         self.data = {}
         self.lock = Lock()
 
@@ -60,13 +60,6 @@ class HDF5:
     def _read_pqual_mapping(self) -> Dict[str, str]:
         return self._read_nqual_mapping(R"PERLND/PQUAL/PQUAL", "QUALID", 10)
 
-    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
-        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
-        df = pd.read_csv(datapath)
-        df = df.set_index(["operation", "activity", "hspf_name"])
-        df_dict = df["hsp2_name"].to_dict()
-        return df_dict
-
     def get_time_series(
         self, operation: str, id: str, constituent: str, activity: str
     ) -> Union[pd.Series, None]:
@@ -100,7 +93,7 @@ class HDF5:
             if constituent_prefix + constituent in df.columns:
                 return df[constituent_prefix + constituent]
             else:
-                constituent_alias = self.aliases[(operation, activity, constituent)]
+                constituent_alias = self.aliases.get_alias((operation, activity, constituent))
                 return df[constituent_prefix + constituent_alias]
         except KeyError:
             return None
@@ -116,3 +109,24 @@ class HDF5:
                 return df
         except KeyError:
             return pd.DataFrame()
+
+
+
+class hsp2_hspf_aliases:
+    REQUIRES_MAPPING = ["GQUAL", "CONS", "IQUAL", "PQUAL"]
+
+    def __init__(self) -> None:
+        self.aliases = self._read_aliases_csv()
+    
+    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
+        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
+        df = pd.read_csv(datapath)
+        df = df.set_index(["operation", "activity", "hspf_name"])
+        df_dict = df["hsp2_name"].to_dict()
+        return df_dict
+    
+    def get_alias(self, params):
+       if params in self.aliases
+           return self.aliases[params]
+       else:
+           return False

--- a/src/hsp2/hsp2tools/names.py
+++ b/src/hsp2/hsp2tools/names.py
@@ -1,0 +1,7 @@
+"""
+Functions that should create paths, combined names, etc. should go here
+"""
+
+def hsp2_sequence_name(activity, ix):
+    s = f"{activity[0]}{int(ix):03d}"
+    return(s)

--- a/src/hsp2/hsp2tools/readUCI.py
+++ b/src/hsp2/hsp2tools/readUCI.py
@@ -530,6 +530,8 @@ def opn(info, lines):
             s = tokens[2].split(":")
             indelt = int(s[0]) if len(s) == 1 else 60 * int(s[0]) + int(s[1])
         elif tokens[0] in ops:
+            # this line makes the unique system wide name for the OPN SEQUENCE
+            # it is so important that it deserves to be its own function.
             s = f"{tokens[0][0]}{int(tokens[1]):03d}"
             lst.append((tokens[0], s, indelt))
     dfopn = pd.DataFrame(lst, columns=["OPERATION", "SEGMENT", "INDELT_minutes"])

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -405,24 +405,24 @@ def state_segname(state, operation, segment, activity):
     seg_path = "/STATE/" + state.model_root_name + "/" + seg_name 
     return (seg_name, seg_path)
 
-def state_init_hsp2(state, opseq, activities, timer):
+
+def state_init_hsp2(state, model):
     # This sets up the state entries for all state compatible HSP2 model variables
-    print("STATE initializing contexts.")
-    for _, operation, segment, delt in opseq.itertuples():
-        seg_name = operation + "_" + segment
-        seg_path = "/STATE/" + state.model_root_name + "/" + seg_name
-        # set up named paths for model operations
-        state.set_state(seg_path, 0.0)
+    # print("STATE initializing contexts.")
+    for operation, activity, segment in model.keys():
         if operation != "GENER" and operation != "COPY":
-            for activity, function in activities[operation].items():
-                if activity == "HYDR":
-                    state_context_hsp2(state, operation, segment, activity)
-                elif activity == "SEDTRN":
-                    state_context_hsp2(state, operation, segment, activity)
-                elif activity == "SEDMNT":
-                    state_context_hsp2(state, operation, segment, activity)
-                elif activity == "RQUAL":
-                    state_context_hsp2(state, operation, segment, activity)
+            if activity == "HYDR":
+                state_context_hsp2(state, operation, segment, activity)
+                hydr_init_ix(state, state["domain"])
+            elif activity == "SEDTRN":
+                state_context_hsp2(state, operation, segment, activity)
+                sedtrn_init_ix(state, state["domain"])
+            elif activity == "SEDMNT":
+                state_context_hsp2(state, operation, segment, activity)
+                sedmnt_init_ix(state, state["domain"])
+            elif activity == "RQUAL":
+                state_context_hsp2(state, operation, segment, activity)
+                rqual_init_ix(state, state["domain"])
 
 
 def state_load_dynamics_hsp2(state, io_manager, siminfo):

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -388,14 +388,14 @@ def state_context_hsp2(state, operation, segment, activity):
     state.activity = activity
     # give shortcut to state path for the upcoming function
     # insure that there is a model object container
-    (seg_name, seg_path) = state_segname(state, operation, segment, activity)
+    (seg_name, seg_path) = state_segname(state, operation, segment)
     #if seg_name not in state.hsp_segments.keys():
     if not nkey_exists(state.hsp_segments, seg_name): # test this for njit
         state.hsp_segments = append_numba_dict(state.hsp_segments, seg_name, seg_path)
     state.domain = state_domain(state, operation, segment, activity)
     
 def state_domain(state, operation, segment, activity):
-    (seg_name, seg_path) = state_segname(state, operation, segment, activity)
+    (seg_name, seg_path) = state_segname(state, operation, segment)
     domain = seg_path # later we may make his custom depending on the operation/activity
     # like + "/" + activity 
     return domain

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -400,29 +400,30 @@ def state_domain(state, operation, segment, activity):
     # like + "/" + activity 
     return domain
     
-def state_segname(state, operation, segment, activity):
+def state_segname(state, operation, segment):
     seg_name = operation + "_" + segment
     seg_path = "/STATE/" + state.model_root_name + "/" + seg_name 
     return (seg_name, seg_path)
 
 
-def state_init_hsp2(state, model):
+def state_init_hsp2(state, opseq, activities):
     # This sets up the state entries for all state compatible HSP2 model variables
     # print("STATE initializing contexts.")
-    for operation, activity, segment in model.keys():
+    for _, operation, segment, delt in opseq.itertuples():
         if operation != "GENER" and operation != "COPY":
-            if activity == "HYDR":
-                state_context_hsp2(state, operation, segment, activity)
-                hydr_init_ix(state, state["domain"])
-            elif activity == "SEDTRN":
-                state_context_hsp2(state, operation, segment, activity)
-                sedtrn_init_ix(state, state["domain"])
-            elif activity == "SEDMNT":
-                state_context_hsp2(state, operation, segment, activity)
-                sedmnt_init_ix(state, state["domain"])
-            elif activity == "RQUAL":
-                state_context_hsp2(state, operation, segment, activity)
-                rqual_init_ix(state, state["domain"])
+            for activity, function in activities[operation].items():
+                if activity == "HYDR":
+                    state_context_hsp2(state, operation, segment, activity)
+                    hydr_init_ix(state, state["domain"])
+                elif activity == "SEDTRN":
+                    state_context_hsp2(state, operation, segment, activity)
+                    sedtrn_init_ix(state, state["domain"])
+                elif activity == "SEDMNT":
+                    state_context_hsp2(state, operation, segment, activity)
+                    sedmnt_init_ix(state, state["domain"])
+                elif activity == "RQUAL":
+                    state_context_hsp2(state, operation, segment, activity)
+                    rqual_init_ix(state, state["domain"])
 
 
 def state_load_dynamics_hsp2(state, io_manager, siminfo):

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -408,22 +408,22 @@ def state_segname(state, operation, segment):
 
 def state_init_hsp2(state, opseq, activities):
     # This sets up the state entries for all state compatible HSP2 model variables
-    # print("STATE initializing contexts.")
+    # print("STATE initializing contexts.")W
     for _, operation, segment, delt in opseq.itertuples():
         if operation != "GENER" and operation != "COPY":
             for activity, function in activities[operation].items():
                 if activity == "HYDR":
                     state_context_hsp2(state, operation, segment, activity)
-                    hydr_init_ix(state, state["domain"])
+                    hydr_init_ix(state, state.domain)
                 elif activity == "SEDTRN":
                     state_context_hsp2(state, operation, segment, activity)
-                    sedtrn_init_ix(state, state["domain"])
+                    sedtrn_init_ix(state, state.domain)
                 elif activity == "SEDMNT":
                     state_context_hsp2(state, operation, segment, activity)
-                    sedmnt_init_ix(state, state["domain"])
+                    sedmnt_init_ix(state, state.domain)
                 elif activity == "RQUAL":
                     state_context_hsp2(state, operation, segment, activity)
-                    rqual_init_ix(state, state["domain"])
+                    rqual_init_ix(state, state.domain)
 
 
 def state_load_dynamics_hsp2(state, io_manager, siminfo):

--- a/src/hsp2/state/state.py
+++ b/src/hsp2/state/state.py
@@ -1,31 +1,289 @@
 """General routines for SPECL"""
 
-import numpy as np
-from pandas import date_range
-from pandas.tseries.offsets import Minute
-from numba.typed import Dict
-from numpy import zeros
-from numba import njit, types  # import the types
-import os
 import importlib.util
+import os
 import sys
 
+import numpy as np
+import numba as nb
+from numba import njit, types, typeof  # import the types supplies int64, float64
+from numba.experimental import jitclass
+from numba.typed import Dict as ntdict
+from numpy import zeros, float64 as npfloat64, int64 as npint64
+from pandas import date_range, DataFrame
+from pandas.tseries.offsets import Minute
+from hsp2.state.state_timer import timer_class
 
-def init_state_dicts():
-    """
-    This contains the base dictionaries used to pass model state amongst modules and custom code plugins
-    """
-    state = {}  # shared state Dictionary, contains numba-ready Dicts
-    state["state_paths"] = Dict.empty(
-        key_type=types.unicode_type, value_type=types.int64
-    )
-    state["state_ix"] = Dict.empty(key_type=types.int64, value_type=types.float64)
-    state["dict_ix"] = Dict.empty(key_type=types.int64, value_type=types.float64[:, :])
-    state["ts_ix"] = Dict.empty(key_type=types.int64, value_type=types.float64[:])
-    # initialize state for hydr
-    # add a generic place to stash model_data for dynamic components
-    state["model_data"] = {}
-    return state
+# Beginning in operation these are likely to be located in model objects when we go fully to that level.
+# But for now, they are here to maintain compatiility with the existing code base
+# Combine these into a spec to create the class
+tindex = date_range("1984-01-01", "2020-12-31", freq=Minute(60))
+
+state_spec = [
+    # the first entries here are NP arrays, fixed dimenstions, and fast
+    ("state_ix", typeof(np.asarray(zeros(1), dtype="float64")) ),
+    ("op_tokens", typeof(types.int64(zeros((1, 64)))) ),
+    ("op_exec_lists", typeof(types.int64(zeros((1, 1024)))) ),
+    ("model_exec_list", typeof(np.asarray(zeros(1), dtype="int64")) ),
+    ("tindex", typeof(tindex.to_numpy()) ),
+    # dict_ix SHOULD BE an array, this is TBD.  Likely defer till OM class runtimes
+    ("dict_ix", types.DictType(types.int64, types.float64[:, :]) ),
+    # below here are dictionaries as they are not used in runtime and can be slow
+    ("state_paths", types.DictType(types.unicode_type, types.int64) ),
+    ("ts_paths", types.DictType(types.unicode_type, types.float64[:]) ),
+    ("ts_ix", types.DictType(types.int64, types.float64[:]) ),
+    ("last_id", types.int64),
+    ("model_root_name", types.unicode_type),
+    ("state_step_hydr", types.unicode_type),
+    ("hsp2_local_py", types.boolean),
+    ("num_ops", types.int64),
+    ("op_len", types.int64),
+    ("operation", types.unicode_type),
+    ("segment", types.unicode_type),
+    ("activity", types.unicode_type),
+    ("domain", types.unicode_type),
+    ("state_step_om", types.unicode_type),
+    ("hsp_segments", types.DictType(types.unicode_type, types.unicode_type) )
+]
+
+
+state_numba = [
+    ("num_ops", nb.int64),
+    # the first entries here are NP arrays, fixed dimenstions, and fast
+    ("state_ix", nb.float64[:]),
+    ("op_tokens", typeof(types.int64(zeros((1, 64)))) ),
+    ("op_exec_lists", typeof(types.int64(zeros((1, 1024)))) ),
+    ("model_exec_list", typeof(np.asarray(zeros(1), dtype="int64")) ),
+    ("tindex", typeof(tindex.to_numpy()) ),
+    # dict_ix SHOULD BE an array, this is TBD.  Likely defer till OM class runtimes
+    ("dict_ix", types.DictType(types.int64, types.float64[:, :]) ),
+    ("ts_ix", types.DictType(types.int64, types.float64[:]) ),
+    ("state_paths", types.DictType(types.unicode_type, types.int64) ),
+    ("last_id", types.int64),
+    ("model_root_name", types.unicode_type),
+    ("state_step_hydr", types.unicode_type),
+    ("hsp2_local_py", types.boolean),
+    ("num_ops", types.int64),
+    ("operation", types.unicode_type),
+    ("segment", types.unicode_type),
+    ("activity", types.unicode_type),
+    ("domain", types.unicode_type),
+    ("state_step_om", types.unicode_type),
+    ("hsp_segments", types.DictType(types.unicode_type, types.unicode_type) )
+]
+
+""" state_numba is a numbafied version of state"""
+@jitclass(state_numba)
+class state_class_numba:
+    def __init__(self, num_ops):
+        self.num_ops = num_ops
+        state_ix = zeros(self.num_ops)
+        self.state_ix = state_ix.astype(npfloat64)
+        op_tokens = zeros((self.num_ops, 64))
+        self.op_tokens = op_tokens.astype(npint64)
+        # TODO: move to individual objects in OM/RCHRES/PERLND/...
+        op_exec_lists = zeros((self.num_ops, 1024))
+        self.op_exec_lists = op_exec_lists.astype(npint64)
+        # TODO: is this even needed? Since each domain has it's own exec list?
+        model_exec_list = zeros(self.num_ops)
+        self.model_exec_list = model_exec_list.astype(npint64)
+        self.activity = ""
+        self.segment = ""
+        self.operation = ""
+        self.domain = ""
+        self.model_root_name = ""
+
+@njit(cache=True)
+def make_state_numba(num_ops):
+    sc = state_class_numba(num_ops)
+    return sc
+
+def state_copy(statesrc, statedest):
+    # copies from a non-jit to a jit or vice versa
+    statedest.num_ops = statesrc.num_ops
+    statedest.state_ix = statesrc.state_ix
+    statedest.dict_ix = statesrc.dict_ix
+    statedest.ts_ix = statesrc.ts_ix
+    statedest.op_tokens = statesrc.op_tokens
+    statedest.op_exec_lists = statesrc.op_exec_lists
+    statedest.model_exec_list = statesrc.model_exec_list
+    statedest.state_paths = statesrc.state_paths
+    statedest.hsp2_local_py = statesrc.hsp2_local_py
+    statedest.model_root_name = statesrc.model_root_name
+    statedest.hsp_segments = statesrc.hsp_segments
+    statedest.state_step_hydr = statesrc.state_step_hydr
+    statedest.state_step_om = statesrc.state_step_om
+    statedest.domain = statesrc.domain
+
+"""
+This function is a simple numba compiled fn to append to a numba dict quickly
+This is necessary because there is no way to just cast a normal dictionary to a numba Dict
+And appending a numba Dict in regular python is super super slow.
+If this does not provide good enough performance when adding a large amount of variables
+We may consider using a jitted loop to copy all elements from a dictionary to Dict
+"""
+@njit(cache=True)
+def append_numba_dict(var_dict, var_key, var_val):
+    var_dict[var_key] = var_val
+    return var_dict
+
+@njit(cache=True)
+def set_numba_value(var_dict, var_key, var_val):
+    var_dict[var_key] = var_val
+    return var_dict
+
+@njit(cache=True)
+def nkey_exists(var_dict, var_key):
+    return (var_key in var_dict)
+
+class state_class:
+    def __init__(self, state_ix, op_tokens, state_paths, op_exec_lists, model_exec_list, dict_ix, ts_ix, hsp_segments):
+        self.num_ops = 0
+        # IMPORTANT these are handled as nparray as numba Dict would be super slow. 
+        # Note: in the type declaration above we are alloweed to use the shortened form op_tokens = int64(zeros((1,64)))
+        #       but in jited class that throws an error and we have to use the form op_tokens.astype(int64)
+        #       to do the type cast
+        self.state_ix = state_ix.astype(npfloat64)
+        self.op_tokens = op_tokens.astype(npint64)
+        # TODO: move to individual objects in OM/RCHRES/PERLND/...
+        self.op_exec_lists = op_exec_lists.astype(npint64)
+        # TODO: is this even needed? Since each domain has it's own exec list?
+        self.model_exec_list = model_exec_list.astype(npint64)
+        # Done with nparray initializations
+        # this dict_ix approach is inherently slow, and should be replaced by some other np table type
+        # on an as-needed basis if possible.  Especially for dataMatrix types which are supposed to be fast
+        # state can still get values via get_state, by grabbing a reference object and then accessing it's storage
+        self.dict_ix = dict_ix
+        self.ts_ix = ts_ix
+        self.state_paths = state_paths
+        self.hsp_segments = hsp_segments
+        self.state_step_om = "disabled"
+        self.state_step_hydr = "disabled"
+        self.model_root_name = ""
+        self.operation = ""
+        self.segment = ""
+        self.activity = ""
+        self.domain = ""
+        self.last_id = 0
+        self.hsp2_local_py = False
+        self.op_len = 64 # how wide is an op list array
+        self.timer = timer_class() # allow us to benchmark performance here
+        return
+    
+    @property
+    def size(self):
+        return self.state_ix.size
+    
+    def append_state(self, var_value):
+        val_ix = self.size  # next ix value= size since ix starts from zero
+        self.state_ix = np.append(self.state_ix, var_value)
+        self.last_id = val_ix
+        self.resize()
+        return val_ix
+    
+    def set_token(self, var_ix, tokens, debug=False):
+        if var_ix not in range(len(self.state_ix)):
+            if debug:
+                print("Undefined index value,", var_ix, ", provided for set_token()")
+            return False
+        if var_ix not in range(np.shape(self.op_tokens)[0]):
+            if debug:
+                print("set_token called for ix", var_ix, ", need to expand")
+            self.resize()
+        # in a perfect world we would insure that the length of tokens is correct
+        # and if not, we would resize.  But this is only called from ModelObject
+        # and its methods add_op_tokens() and model_format_ops(ops) enforce the
+        # length limit described by ModelObject.max_token_length (64) which must match
+        self.op_tokens[var_ix] = tokens
+    
+    def resize(self, debug=False):
+        num_ops = self.size
+        # print("state_ix has", num_ops, "elements")
+        ops_needed = num_ops - np.shape(self.op_tokens)[0]
+        if ops_needed == 0:
+            # print("resize op_tokens unneccesary, state has", self.size,"indices and op_tokens has", np.shape(self.op_tokens)[0], "elements")
+            return
+        if debug:
+            print("op_tokens needs", ops_needed, "slots")
+        add_ops = np.full((ops_needed,self.op_len),-1) # fill with -1
+        zeros((ops_needed, 64))
+        # print("Created add_ops with", ops_needed, "slots")
+        # we use the 3rd param "axis=1" to prevent flattening of array
+        if self.op_tokens.size == 0:
+            if debug:
+                print("Creating op_tokens")
+            self.op_tokens = add_ops.astype(npint64)
+        else:
+            if debug:
+                print("Merging op_tokens")
+            add_ops = np.append(self.op_tokens, add_ops, 0)
+            self.op_tokens = add_ops.astype(npint64)
+        ops_needed = num_ops - np.shape(self.op_exec_lists)[0]
+        el_width = np.shape(self.op_exec_lists)[1]
+        if debug:
+            print("op_exec_lists needs", ops_needed, "slots")
+        if ops_needed == 0:
+            return
+        add_ops = zeros((ops_needed, el_width))
+        # we use the 3rd param "axis=1" to prevent flattening of array
+        if self.op_exec_lists.size == 0:
+            if debug:
+                print("Creating op_exec_lists")
+            self.op_exec_lists = add_ops.astype(npint64)
+        else:
+            if debug:
+                print("Merging op_exec_lists")
+            add_ops = np.append(self.op_exec_lists, add_ops, 0)
+            self.op_exec_lists = add_ops.astype(npint64)
+        return
+    
+    def set_exec_list(self, ix, op_exec_list):
+        for i in range(len(op_exec_list)):
+            self.op_exec_lists[ix][i] = op_exec_list[i]
+    
+    def set_state(self, var_path, var_value=0.0, debug=False):
+        """
+        Given an hdf5 style path to a variable, set the value
+        If the variable does not yet exist, create it.
+        Returns the integer key of the variable in the state_ix Dict
+        """
+        if not nkey_exists(self.state_paths, var_path):
+        #if var_path not in self.state_paths:
+            # we need to add this to the state
+            var_ix = self.append_state(var_value)
+            self.state_paths = append_numba_dict(self.state_paths, var_path, var_ix)
+        else:
+            var_ix = self.get_state_ix(var_path)
+            #self.state_ix[var_ix] = var_value
+            self.state_ix = set_numba_value(self.state_ix, var_ix, var_value)
+            #append_numba_dict(self.state_ix, var_value, var_ix)
+        if debug:
+            print("Setting state_ix[", var_ix, "], to", var_value)
+        return var_ix
+    
+    def get_state_ix(self, var_path):
+        """
+        Find the integer key of a variable name in state_ix
+        """
+        if var_path == False:
+            # handle a bad path with False
+            return False
+        if var_path not in self.state_paths:
+            # we need to add this to the state
+            return False  # should throw an error
+        var_ix = self.state_paths[var_path]
+        return var_ix
+    
+    def get_ix_path(self, var_ix):
+        """
+        Find the path of a variable with integer key in state_ix
+        """
+        spath = None
+        for spath, ix in self.state_paths.items():
+            if var_ix == ix:
+                # we need to add this to the state
+                return spath
+        return spath
 
 
 def op_path_name(operation, id):
@@ -36,8 +294,8 @@ def op_path_name(operation, id):
     path_name = f"{operation}_{operation[0]}{tid}"
     return path_name
 
-
-def get_state_ix(state_ix, state_paths, var_path):
+@njit(cache=True)
+def get_state_ix(state_paths, var_path):
     """
     Find the integer key of a variable name in state_ix
     """
@@ -46,17 +304,6 @@ def get_state_ix(state_ix, state_paths, var_path):
         return False  # should throw an error
     var_ix = state_paths[var_path]
     return var_ix
-
-
-def get_ix_path(state_paths, var_ix):
-    """
-    Find the path of a variable with integer key in state_ix
-    """
-    for spath, ix in state_paths.items():
-        if var_ix == ix:
-            # we need to add this to the state
-            return spath
-    return False
 
 
 def set_state(state_ix, state_paths, var_path, default_value=0.0, debug=False):
@@ -81,15 +328,15 @@ def state_add_ts(state, var_path, default_value=0.0, debug=False):
     If the variable does not yet exist, create it.
     Returns the integer key of the variable in the state_ix Dict
     """
-    if var_path not in state["state_paths"].keys():
+    if var_path not in state.state_paths.keys():
         # we need to add this to the state
-        state["state_paths"][var_path] = append_state(state["state_ix"], default_value)
-    var_ix = get_state_ix(state["state_ix"], state["state_paths"], var_path)
+        state.state_paths[var_path] = append_state(state.state_ix, default_value)
+    var_ix = get_state_ix(state.state_ix, state.state_paths, var_path)
     if debug == True:
         print("Setting state_ix[", var_ix, "], to", default_value)
     # siminfo needs to be in the model_data array of state.  Can be populated by HSP2 or standalone by ops model
-    state["ts_ix"][var_ix] = np.full_like(
-        zeros(state["model_data"]["siminfo"]["steps"]), default_value
+    state.ts_ix[var_ix] = np.full_like(
+        zeros(om_operations["model_data"]["steps"]), default_value
     )
     return var_ix
 
@@ -120,56 +367,71 @@ def append_state(state_ix, var_value):
     return val_ix
 
 
-def state_context_hsp2(state, operation, segment, activity):
-    # this establishes domain info so that a module can know its paths
-    state["operation"] = operation
-    state["segment"] = segment  #
-    state["activity"] = activity
-    # give shortcut to state path for the upcoming function
-    # insure that there is a model object container
-    seg_name = operation + "_" + segment
-    seg_path = "/STATE/" + state["model_root_name"] + "/" + seg_name
-    if "hsp_segments" not in state.keys():
-        state[
-            "hsp_segments"
-        ] = {}  # for later use by things that need to know hsp entities and their paths
-    if seg_name not in state["hsp_segments"].keys():
-        state["hsp_segments"][seg_name] = seg_path
-
-    state["domain"] = seg_path  # + "/" + activity   # may want to comment out activity?
-
-
-def state_siminfo_hsp2(parameter_obj, siminfo, io_manager, state):
+def state_siminfo_hsp2(state, parameter_obj, io_manager):
     # Add crucial simulation info for dynamic operation support
     delt = parameter_obj.opseq.INDELT_minutes[0]  # get initial value for STATE objects
-    siminfo["delt"] = delt
-    siminfo["tindex"] = date_range(
-        siminfo["start"], siminfo["stop"], freq=Minute(delt)
+    parameter_obj.siminfo["delt"] = delt
+    parameter_obj.siminfo["tindex"] = date_range(
+        parameter_obj.siminfo["start"], parameter_obj.siminfo["stop"], freq=Minute(delt)
     )[1:]
-    siminfo["steps"] = len(siminfo["tindex"])
+    parameter_obj.siminfo["steps"] = len(parameter_obj.siminfo["tindex"])
+    state.tindex = parameter_obj.siminfo["tindex"].to_numpy()
     hdf5_path = io_manager._input.file_path
     (fbase, fext) = os.path.splitext(hdf5_path)
-    state["model_root_name"] = os.path.split(fbase)[1]  # takes the text before .h5
+    state.model_root_name = os.path.split(fbase)[1]  # takes the text before .h5
 
+#@njit(cache=True)
+def state_context_hsp2(state, operation, segment, activity):
+    # this establishes domain info so that a module can know its paths
+    state.operation = operation
+    state.segment = segment  #
+    state.activity = activity
+    # give shortcut to state path for the upcoming function
+    # insure that there is a model object container
+    (seg_name, seg_path) = state_segname(state, operation, segment, activity)
+    #if seg_name not in state.hsp_segments.keys():
+    if not nkey_exists(state.hsp_segments, seg_name): # test this for njit
+        state.hsp_segments = append_numba_dict(state.hsp_segments, seg_name, seg_path)
+    state.domain = state_domain(state, operation, segment, activity)
+    
+def state_domain(state, operation, segment, activity):
+    (seg_name, seg_path) = state_segname(state, operation, segment, activity)
+    domain = seg_path # later we may make his custom depending on the operation/activity
+    # like + "/" + activity 
+    return domain
+    
+def state_segname(state, operation, segment, activity):
+    seg_name = operation + "_" + segment
+    seg_path = "/STATE/" + state.model_root_name + "/" + seg_name 
+    return (seg_name, seg_path)
 
-def state_init_hsp2(state, opseq, activities):
+def state_init_hsp2(state, opseq, activities, timer):
     # This sets up the state entries for all state compatible HSP2 model variables
-    # print("STATE initializing contexts.")
+    print("STATE initializing contexts.")
     for _, operation, segment, delt in opseq.itertuples():
+        seg_name = operation + "_" + segment
+        seg_path = "/STATE/" + state.model_root_name + "/" + seg_name
+        # set up named paths for model operations
+        state.set_state(seg_path, 0.0)
         if operation != "GENER" and operation != "COPY":
             for activity, function in activities[operation].items():
                 if activity == "HYDR":
                     state_context_hsp2(state, operation, segment, activity)
-                    hydr_init_ix(state, state["domain"])
                 elif activity == "SEDTRN":
                     state_context_hsp2(state, operation, segment, activity)
-                    sedtrn_init_ix(state, state["domain"])
                 elif activity == "SEDMNT":
                     state_context_hsp2(state, operation, segment, activity)
-                    sedmnt_init_ix(state, state["domain"])
                 elif activity == "RQUAL":
                     state_context_hsp2(state, operation, segment, activity)
-                    rqual_init_ix(state, state["domain"])
+
+
+def state_load_dynamics_hsp2(state, io_manager, siminfo):
+    # Load any dynamic components if present, and store variables on objects
+    # if a local file with state_step_hydr() was found in load_dynamics(), we add it to state
+    state.hsp2_local_py = load_dynamics(
+        io_manager, siminfo
+    )  # Stores the actual function in state
+    state.state_step_hydr = siminfo["state_step_hydr"]  # enabled or disabled
 
 
 def state_load_hdf5_components(
@@ -184,14 +446,6 @@ def state_load_hdf5_components(
 ):
     # Implement population of model_object_cache etc from components in a hdf5 such as Special ACTIONS
     return
-
-
-def state_load_dynamics_hsp2(state, io_manager, siminfo):
-    # Load any dynamic components if present, and store variables on objects
-    hsp2_local_py = load_dynamics(io_manager, siminfo)
-    # if a local file with state_step_hydr() was found in load_dynamics(), we add it to state
-    state["state_step_hydr"] = siminfo["state_step_hydr"]  # enabled or disabled
-    state["hsp2_local_py"] = hsp2_local_py  # Stores the actual function in state
 
 
 @njit
@@ -251,14 +505,16 @@ def hydr_state_vars():
     ]
 
 
-def hydr_init_ix(state, domain):
+def hydr_init_ix(state, domain, debug = False):
     # get a list of keys for all hydr state variables
     hydr_state = hydr_state_vars()
-    hydr_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    hydr_ix = DataFrame()
     for i in hydr_state:
         # var_path = f'{domain}/{i}'
         var_path = domain + "/" + i
-        hydr_ix[i] = set_state(state["state_ix"], state["state_paths"], var_path, 0.0)
+        if debug:
+            print("initializing", var_path)
+        hydr_ix[i] = state.set_state(var_path, 0.0)
     return hydr_ix
 
 
@@ -270,11 +526,11 @@ def sedtrn_state_vars():
 def sedtrn_init_ix(state, domain):
     # get a list of keys for all sedtrn state variables
     sedtrn_state = sedtrn_state_vars()
-    sedtrn_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    sedtrn_ix = DataFrame()
     for i in sedtrn_state:
         # var_path = f'{domain}/{i}'
         var_path = domain + "/" + i
-        sedtrn_ix[i] = set_state(state["state_ix"], state["state_paths"], var_path, 0.0)
+        sedtrn_ix[i] = state.set_state(var_path, 0.0)
     return sedtrn_ix
 
 
@@ -286,13 +542,14 @@ def sedmnt_state_vars():
 def sedmnt_init_ix(state, domain):
     # get a list of keys for all sedmnt state variables
     sedmnt_state = sedmnt_state_vars()
-    sedmnt_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    sedmnt_ix = DataFrame()
     for i in sedmnt_state:
         var_path = domain + "/" + i
-        sedmnt_ix[i] = set_state(state["state_ix"], state["state_paths"], var_path, 0.0)
+        sedmnt_ix[i] = state.set_state(var_path, 0.0)
     return sedmnt_ix
 
 
+@njit(cache=True)
 def rqual_state_vars():
     rqual_state = [
         "DOX",
@@ -309,19 +566,18 @@ def rqual_state_vars():
     ]
     return rqual_state
 
-
 def rqual_init_ix(state, domain):
     # get a list of keys for all rqual state variables
     rqual_state = rqual_state_vars()
-    rqual_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    rqual_ix = DataFrame()
     for i in rqual_state:
         var_path = domain + "/" + i
-        rqual_ix[i] = set_state(state["state_ix"], state["state_paths"], var_path, 0.0)
+        rqual_ix[i] = state.set_state(var_path, 0.0)
     return rqual_ix
 
 
-@njit
-def hydr_get_ix(state_ix, state_paths, domain):
+@njit(cache=True)
+def hydr_get_ix(state, domain):
     # get a list of keys for all hydr state variables
     hydr_state = [
         "DEP",
@@ -341,38 +597,40 @@ def hydr_get_ix(state_ix, state_paths, domain):
         "VOL",
         "VOLEV",
     ]
-    hydr_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    # print(state.state_paths)
+    hydr_ix = ntdict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in hydr_state:
         # var_path = f'{domain}/{i}'
         var_path = domain + "/" + i
-        hydr_ix[i] = state_paths[var_path]
+        # print("looking for:", var_path)
+        hydr_ix[i] = get_state_ix(state.state_paths, var_path)
     return hydr_ix
 
 
-@njit
-def sedtrn_get_ix(state_ix, state_paths, domain):
+@njit(cache=True)
+def sedtrn_get_ix(state, domain):
     # get a list of keys for all sedtrn state variables
     sedtrn_state = ["RSED4", "RSED5", "RSED6"]
-    sedtrn_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    sedtrn_ix = ntdict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in sedtrn_state:
         var_path = domain + "/" + i
-        sedtrn_ix[i] = state_paths[var_path]
+        sedtrn_ix[i] = get_state_ix(state.state_paths, var_path)
     return sedtrn_ix
 
 
-@njit
-def sedmnt_get_ix(state_ix, state_paths, domain):
+@njit(cache=True)
+def sedmnt_get_ix(state, domain):
     # get a list of keys for all sedmnt state variables
     sedmnt_state = ["DETS"]
-    sedmnt_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    sedmnt_ix = ntdict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in sedmnt_state:
         var_path = domain + "/" + i
-        sedmnt_ix[i] = state_paths[var_path]
+        sedmnt_ix[i] = get_state_ix(state.state_paths, var_path)
     return sedmnt_ix
 
 
 @njit
-def rqual_get_ix(state_ix, state_paths, domain):
+def rqual_get_ix(state, domain):
     # get a list of keys for all sedmnt state variables
     rqual_state = [
         "DOX",
@@ -387,10 +645,10 @@ def rqual_get_ix(state_ix, state_paths, domain):
         "BRPO42",
         "CFOREA",
     ]
-    rqual_ix = Dict.empty(key_type=types.unicode_type, value_type=types.int64)
+    rqual_ix = ntdict.empty(key_type=types.unicode_type, value_type=types.int64)
     for i in rqual_state:
         var_path = domain + "/" + i
-        rqual_ix[i] = state_paths[var_path]
+        rqual_ix[i] = get_state_ix(state.state_paths, var_path)
     return rqual_ix
 
 

--- a/src/hsp2/state/state_definitions.py
+++ b/src/hsp2/state/state_definitions.py
@@ -1,0 +1,31 @@
+# null function to be loaded when not supplied by user
+from numba import njit  # import the types
+from numba.typed import Dict
+from numba import types  # import the types
+from numpy import zeros
+
+state_empty = {}  # shared state Dictionary, contains numba-ready Dicts
+state_empty["state_paths"] = Dict.empty(
+    key_type=types.unicode_type, value_type=types.int64
+)
+state_empty["state_ix"] = types.float64(zeros(0))
+state_empty["dict_ix"] = Dict.empty(key_type=types.int64, value_type=types.float64[:, :])
+state_empty["ts_ix"] = Dict.empty(key_type=types.int64, value_type=types.float64[:])
+state_empty["hsp_segments"] = Dict.empty(key_type=types.unicode_type, value_type=types.unicode_type)
+state_empty["op_tokens"] = types.int64(zeros((0, 64)))
+state_empty["model_exec_list"] = types.int64(zeros(0))
+state_empty["op_exec_lists"] = types.int64(zeros((0, 1024)))
+
+# initialize state for hydr
+# add a generic place to stash model_data for dynamic components
+state_empty["model_data"] = {}
+
+# variables: these could go into individual files later or in object defs
+rqual_state_vars = [ 
+    "DOX", "BOD", "NO3", "TAM", "NO2", "PO4", "BRTAM1",
+    "BRTAM2", "BRPO41", "BRPO42", "CFOREA"
+]
+
+@njit
+def state_step_hydr(state, step):
+    return

--- a/src/hsp2/state/state_timer.py
+++ b/src/hsp2/state/state_timer.py
@@ -1,0 +1,57 @@
+"""
+These class timer_class/timer_class_jit is used for benchmarking and peformance inquiry.
+The goal is to have internal benchmarking under python and jitted python simulations.
+"""
+
+from numba.experimental import jitclass
+import ctypes
+import time
+from numba import njit, types
+
+# Access the _PyTime_AsSecondsDouble and _PyTime_GetSystemClock functions from pythonapi
+get_system_clock = ctypes.pythonapi._PyTime_GetSystemClock
+as_seconds_double = ctypes.pythonapi._PyTime_AsSecondsDouble
+# Set the argument types and return types of the functions
+get_system_clock.argtypes = []
+get_system_clock.restype = ctypes.c_int64
+as_seconds_double.argtypes = [ctypes.c_int64]
+as_seconds_double.restype = ctypes.c_double
+
+timer_spec = [
+     ("tstart", types.float64),
+     ("tend", types.float64),
+     ("tsplit", types.float64)
+]
+
+@njit
+def jitime():
+    system_clock = get_system_clock()
+    current_time = as_seconds_double(system_clock)
+    return current_time
+
+@jitclass(timer_spec)
+class timer_class_jit():
+    def __init__(self):
+        self.tstart = jitime()
+    
+    def split(self):
+        self.tend = jitime()
+        self.tsplit = self.tend - self.tstart
+        self.tstart = jitime()
+        split = 0
+        if (self.tsplit > 0):
+            split = self.tsplit
+        return split
+
+class timer_class():
+    def __init__(self):
+        self.tstart = time.time()
+    
+    def split(self):
+        self.tend = time.time()
+        self.tsplit = self.tend - self.tstart
+        self.tstart = time.time()
+        split = 0
+        if (self.tsplit > 0):
+            split = self.tsplit
+        return split

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Tuple, Union
 import numpy as np
 import pandas as pd
 from hsp2.hsp2tools.HBNOutput import HBNOutput
-from hsp2.hsp2tools.HDF5 import HDF5
+from hsp2.hsp2tools.HDF5 import HDF5, hsp2_hspf_aliases
 import hsp2.hsp2tools as hsp2tools
 
 OperationsTuple = Tuple[str, str, str, str, str]
@@ -32,7 +32,7 @@ class RegressTest:
         self.ids = ids
         self.threads = threads
         self.quiet = False # allows users to set this later
-        self.aliases = self._read_aliases_csv() # compatibility map btwn hspf:hsp2
+        self.aliases = hsp2_hspf_aliases() # compatibility map btwn hspf:hsp2
         self._init_files()
 
     def _init_files(self):

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -8,8 +8,7 @@ from typing import Dict, List, Tuple, Union
 import numpy as np
 import pandas as pd
 from hsp2.hsp2tools.HBNOutput import HBNOutput
-from hsp2.hsp2tools.HDF5 import HDF5, hsp2_hspf_aliases
-import hsp2.hsp2tools as hsp2tools
+from hsp2.hsp2tools.HDF5 import HDF5
 
 OperationsTuple = Tuple[str, str, str, str, str]
 ResultsTuple = Tuple[bool, bool, bool, float]
@@ -32,7 +31,6 @@ class RegressTest:
         self.ids = ids
         self.threads = threads
         self.quiet = False # allows users to set this later
-        self.aliases = hsp2_hspf_aliases() # compatibility map btwn hspf:hsp2
         self._init_files()
 
     def _init_files(self):
@@ -343,10 +341,3 @@ class RegressTest:
 
         match = np.allclose(ts_hspf, ts_hsp2, rtol=1e-2, atol=tol, equal_nan=False)
         return (match, max_diff)
-    
-    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
-        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
-        df = pd.read_csv(datapath)
-        df = df.set_index(["operation", "activity", "hspf_name"])
-        df_dict = df["hsp2_name"].to_dict()
-        return df_dict

--- a/tests/convert/regression_base.py
+++ b/tests/convert/regression_base.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from hsp2.hsp2tools.HBNOutput import HBNOutput
 from hsp2.hsp2tools.HDF5 import HDF5
+import hsp2.hsp2tools as hsp2tools
 
 OperationsTuple = Tuple[str, str, str, str, str]
 ResultsTuple = Tuple[bool, bool, bool, float]
@@ -31,6 +32,7 @@ class RegressTest:
         self.ids = ids
         self.threads = threads
         self.quiet = False # allows users to set this later
+        self.aliases = self._read_aliases_csv() # compatibility map btwn hspf:hsp2
         self._init_files()
 
     def _init_files(self):
@@ -341,3 +343,10 @@ class RegressTest:
 
         match = np.allclose(ts_hspf, ts_hsp2, rtol=1e-2, atol=tol, equal_nan=False)
         return (match, max_diff)
+    
+    def _read_aliases_csv(self) -> Dict[Tuple[str, str, str], str]:
+        datapath = os.path.join(hsp2tools.__path__[0], "data", "HBNAliases.csv")
+        df = pd.read_csv(datapath)
+        df = df.set_index(["operation", "activity", "hspf_name"])
+        df_dict = df["hsp2_name"].to_dict()
+        return df_dict

--- a/tests/testcbp/HSP2results/check_equation.py
+++ b/tests/testcbp/HSP2results/check_equation.py
@@ -9,7 +9,7 @@ from hsp2.hsp2io.hdf import HDF5
 from hsp2.hsp2io.io import IOManager
 from hsp2.state.state import *
 
-fpath = "./tests/testcbp/HSP2results/JL1_6562_6560.h5"
+fpath = "./tests/test10specl/HSP2results/test10specl.h5"
 # try also:
 # fpath = './tests/testcbp/HSP2results/JL1_6562_6560.h5'
 # sometimes when testing you may need to close the file, so try:
@@ -17,36 +17,18 @@ fpath = "./tests/testcbp/HSP2results/JL1_6562_6560.h5"
 # # f.close()
 hdf5_instance = HDF5(fpath)
 io_manager = IOManager(hdf5_instance)
-uci_obj = io_manager.read_uci()
-siminfo = uci_obj.siminfo
-opseq = uci_obj.opseq
+parameter_obj = io_manager.read_parameters()
+ddext_sources = parameter_obj.ddext_sources
+siminfo = parameter_obj.siminfo
+opseq = parameter_obj.opseq
 # Note: now that the UCI is read in and hdf5 loaded, you can see things like:
-# - hdf5_instance._store.keys() - all the paths in the UCI/hdf5
-# - finally stash specactions in state, not domain (segment) dependent so do it once
-# now load state and the special actions
-state = init_state_dicts()
-state_initialize_om(state)
-state["specactions"] = uci_obj.specactions  # stash the specaction dict in state
+(state, om_operations, statenb) = om_state_hsp2_run_setup(parameter_obj, io_manager, activities)
 
-state_siminfo_hsp2(uci_obj, siminfo)
-# Add support for dynamic functions to operate on STATE
-# - Load any dynamic components if present, and store variables on objects
-state_load_dynamics_hsp2(state, io_manager, siminfo)
-# Iterate through all segments and add crucial paths to state
-# before loading dynamic components that may reference them
-state_init_hsp2(state, opseq, activities)
-state_load_dynamics_specl(state, io_manager, siminfo)  # traditional special actions
-state_load_dynamics_om(
-    state, io_manager, siminfo
-)  # operational model for custom python
-state_om_model_run_prep(
-    state, io_manager, siminfo
-)  # this creates all objects from the UCI and previous loads
 # state['model_root_object'].find_var_path('RCHRES_R001')
 # Get the timeseries naked, without an object
-Rlocal = state["model_object_cache"]["/STATE/RCHRES_R001/Rlocal"]
+rchres1 = om_operations["model_object_cache"]["/STATE/test10specl/RCHRES_R001"]
+Rlocal = rchres1.get_object('Rlocal')
 Rlocal_ts = Rlocal.read_ts()
-rchres1 = state["model_object_cache"]["/STATE/RCHRES_R001"]
 Rlocal_check = ModelLinkage(
     "Rlocal1", rchres1, {"right_path": "/TIMESERIES/TS010", "link_type": 3}
 )


### PR DESCRIPTION
NOT READY TO MERGE (Reason: review of concepts pending) -- replaces #202

This PR includes an overhaul to the model `state` system, leveraging a new object-oriented version of `state`, which accomplishes the following:
- It streamlines the number of arguments passed to functions, so now, the arg `state` takes the place of `state_ix`, `dict_ix`, `ts_ix`, ...
- Declarations of the base containers for state attributes is moved outside of the function, living directly in the state.py file, which allows these to be cached, resulting in a huge improvement in performance (recent branches had seen start-up time double due to less optimal numba caching).
- An example of using dynamic equations has been added in `tests/testcbp/HSP2results/` to test a 500 equation addon simulation (Use: `cp PL3_5250_0001.json.manyeq PL3_5250_0001.json` to test).
- Some cleanup of arguments in function like `hydr()` and `sedtrn()` to eliminate the argument `io_manager` as this is no longer used (I think this has been due for a while, I don't think it is due to any changes that I recall making to the code but it seems like a cleaner approach)